### PR TITLE
Copilot/create nextjs frontend

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,95 @@
+# ChessTransformer AI Agent Instructions
+
+## Project Overview
+This project explores using transformer architectures for chess engines, treating chess moves as sequences similar to NLP. The hypothesis: transformers can learn chess patterns like they learn language patterns.
+
+## Architecture: Two Parallel Approaches
+
+### 1. **Move Sequence → Move Sequence** (`src/chesstransformer/models/transformer/gpt.py`)
+- GPT-style autoregressive model predicting next move from move history
+- Dataset: `LichessSimpleUciDataset` (processes .pgn.zst files on-the-fly)
+- Status: Initial implementation showed promise but struggled with legal move consistency
+
+### 2. **Position → Move** (`src/chesstransformer/models/transformer/position2move.py`)
+- Current active approach (see branch `position_based_model`)
+- Input: 64-token board representation (one token per square) + turn indicator
+- Output: Next move prediction from 1968-token move vocabulary
+- Uses triple embedding: token (13 pieces) + position (64 squares) + player (2 colors)
+- Dataset: HDF5 format for efficiency (`HDF5ChessDataset` + `PGNtoHDF5Converter`)
+
+## Key Tokenization Strategy
+
+**Position Tokenizer** (`position_tokenizer.py`):
+- 13-token vocabulary: empty (0), 6 white pieces (1-6), 6 black pieces (7-12)
+- Encodes board as flat 64-element array (a1→h1, a2→h2, ..., a8→h8)
+- Board representation is flipped from chess.Board's internal ordering
+
+**Move Tokenizer** (`move_tokenizer.py`):
+- Vocabulary of 1968 legal chess moves in UCI format
+- Pre-computed vocab stored in `data/tokenizer_models/chess_moves_vocab.json`
+- All moves follow UCI notation (e.g., `e2e4`, `e7e8q` for promotion)
+
+## Data Pipeline
+
+1. **Source**: Lichess rated games (`.pgn.zst` compressed format in `data/`)
+2. **Conversion**: `dataset_h5_convertor.py` → HDF5 with gzip compression
+   - Run as: `python src/chesstransformer/datasets/dataset_h5_convertor.py`
+3. **Training Dataset**: `h5_lichess_dataset.py` with LRU caching
+   - Structure: `{'position': tensor(64), 'move': tensor(1), 'is_white': bool, 'game_id': int}`
+
+## Training Workflow
+
+**Trainer**: `moveseq2moveseq_trainer.py` (adapts for both model types)
+- Uses Hugging Face Accelerate for multi-GPU/mixed precision
+- Custom loss: `llm_loss + 10 * l2_illegal_moves_penalty`
+- Illegal move masking via `legal_moves_mask` tensor
+- TensorBoard logging with auto-incrementing run numbers (`logs/run_XXX_YYYYMMDD_HHMMSS/`)
+- Learning rate: warmup (1000 steps) → linear decay
+- Gradient accumulation for effective large batch sizes
+
+**Key Training Command Pattern**:
+```python
+python src/chesstransformer/trainers/moveseq2moveseq_trainer.py
+```
+
+## Project Conventions
+
+- **Package management**: Uses `hatchling` build system (NOT Poetry/setuptools)
+- **Virtual env**: Expects `.venv` in project root (created via `pip install -e .`)
+- **Model checkpoints**: Stored in both `data/models/` and `src/chesstransformer/models/`
+- **Notebooks**: Used for experimentation (`notebooks/`), not production code
+- **Tests**: unittest framework, run via `python -m unittest` from project root
+
+## Critical Development Details
+
+**When working with datasets**:
+- Always use `zstandard` decompression for .pgn.zst files
+- Skip non-Standard variants (`variant != "Standard"`)
+- HDF5 files use resizable datasets with chunked compression
+- Default chunk size: 10,000 positions
+
+**When working with transformers**:
+- Config dict pattern: `{"embed_dim": 512, "num_heads": 8, "context_size": 64, ...}`
+- All models use custom `LayerNorm` and `GELU` implementations (see `utils.py`)
+- Attention uses causal masking via `mask_future` parameter
+- Position embeddings differ: GPT uses sequence positions, Position2Move uses board square positions
+
+**Chess-specific considerations**:
+- Legal move enforcement is soft (L2 penalty), not hard filtering
+- Game outcomes encoded as special tokens for supervised learning signal
+- python-chess library is the canonical interface for board logic
+- UCI format is standard throughout (no SAN/algebraic notation)
+
+## Documentation References
+
+- **Design rationale**: `doc/design_stategy.md` (explains move-seq vs position-based approaches)
+- **Tokenization details**: `doc/tokenization.md` (comprehensive UCI strategy breakdown)
+- **Transformer theory**: `doc/transformer.md` (project-specific architecture decisions)
+
+## Common Pitfalls
+
+1. **Board orientation**: `PostionTokenizer` flips board order - verify array indexing matches chess squares
+2. **Vocab paths**: Tokenizers default to `data/tokenizer_models/` - use absolute paths when unsure
+3. **TensorBoard conflicts**: Multiple runs can interfere - always increment run numbers
+4. **H5 file locking**: Close HDF5 files properly or risk corruption
+5. **Gradient accumulation**: `accelerator.sync_gradients` check is required for proper metric logging

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Required for Docker standalone build
   output: "standalone",
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.chesscomfiles.com',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request introduces a significant enhancement to the chess game UI by adding comprehensive move history navigation, allowing users to view and traverse previous board states. It also updates project documentation and improves configuration for image hosting. The most important changes are grouped below:

### Chess Game UI Improvements

* Added move history tracking with `positionHistory` and `viewingMoveIndex` state variables in `ChessGame.tsx`, enabling navigation through previous board positions.
* Implemented keyboard (arrow keys) and button-based navigation for move history, including functions to jump to first, previous, next, and last moves. Disabled board interaction when viewing historical positions. [[1]](diffhunk://#diff-5941f0014af180df4f3e5f9d4390c222c567b160acd66e712e92d279f0ad704eR92-R126) [[2]](diffhunk://#diff-5941f0014af180df4f3e5f9d4390c222c567b160acd66e712e92d279f0ad704eR250) [[3]](diffhunk://#diff-5941f0014af180df4f3e5f9d4390c222c567b160acd66e712e92d279f0ad704eR284) F6de19adL610R610, [[4]](diffhunk://#diff-5941f0014af180df4f3e5f9d4390c222c567b160acd66e712e92d279f0ad704eR678-R724)
* Updated the move list table to allow clicking on individual moves to jump directly to that position, with visual highlighting for the currently viewed move.
* Added a UI overlay to indicate when the user is viewing a historical move and updated the help tip to reflect new navigation features. [[1]](diffhunk://#diff-5941f0014af180df4f3e5f9d4390c222c567b160acd66e712e92d279f0ad704eR639-R644) [[2]](diffhunk://#diff-5941f0014af180df4f3e5f9d4390c222c567b160acd66e712e92d279f0ad704eL709-R829)

### Project Documentation

* Added `.github/copilot-instructions.md` detailing the ChessTransformer AI project, its architecture, tokenization, data pipeline, training workflow, conventions, and common pitfalls.

### Configuration

* Updated `next.config.ts` to support remote image loading from `images.chesscomfiles.com`, required for Docker standalone builds.