### PR TITLE
Faster & stronger inference: MCTS engine + search tuning + v2.1 model (~2100 Elo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A transformer-based chess engine trained on elite Lichess games. The model learns to predict moves directly from board positions, then plays via an AlphaZero-style MCTS (policy priors + value head), with a compiled alpha-beta engine as an alternative.
 
-**Current strength: ~1775 Elo** (MCTS @ 400 sims, model v2.1, vs Stockfish — 140-game gauntlet over skills 0–12, June 2026)
+**Current strength: ~2075 Elo** (MCTS @ 800 sims with FPU + tuned c_puct, model v2.1, vs Stockfish — MLE estimate over a 140-game gauntlet, skills 0–12, June 2026)
 
 ## Architecture — Pos2MoveV2
 
@@ -22,24 +22,24 @@ A transformer-based chess engine trained on elite Lichess games. The model learn
 
 Two search engines share the same network (`Pos2MoveV2`):
 
-- **MCTS / PUCT** (`Pos2MoveV2MctsBot`, default) — AlphaZero-style. Uses the policy head as priors and the value head at leaves; picks the most-visited move. Batched-leaf evaluation with virtual loss collects several leaves per network call, amortizing the GPU→CPU sync (~8× faster than single-leaf). Beat the alpha-beta engine ~82% head-to-head.
+- **MCTS / PUCT** (`Pos2MoveV2MctsBot`, default) — AlphaZero-style. Policy head → priors, value head → leaf scores, most-visited move chosen. Batched-leaf evaluation with virtual loss amortizes the GPU→CPU sync (~8× faster than single-leaf). Tuned for **exploitation**: first-play-urgency (`fpu=0.2`) and `c_puct=1.0` (flatter priors / more exploration both lost). With FPU the search scales with simulations, so the default is **800 sims**.
 - **Alpha-beta** (`Pos2MoveV2Bot`) — iterative-deepening negamax with quiescence search, policy-prior move ordering, and a Zobrist transposition table.
 
 Both run a `torch.compile`/CUDA-graph forward (~2.3× faster, lossless).
 
 ## Elo Evaluation
 
-MCTS @ 400 sims, model v2.1, 20 games/level vs Stockfish (`scripts/tune_vs_stockfish.py`):
+MCTS @ 800 sims (`c_puct=1.0`, `fpu=0.2`), model v2.1, 20 games/level vs Stockfish (`scripts/tune_vs_stockfish.py`):
 
 | Stockfish skill | Approx. Elo | Score |
 |---|---|---|
-| 0–4 | ≤ 1200 | 95–100% |
-| 6 | ~1500 | 70% |
-| 8 | ~1700 | 62.5% |
-| 10 | ~1900 | 40% |
-| 12 | ~2100 | 27.5% |
+| 0–4 | ≤ 1200 | 100% |
+| 6 | ~1500 | 97.5% |
+| 8 | ~1700 | 100% |
+| 10 | ~1900 | 62.5% |
+| 12 | ~2100 | 47.5% |
 
-**Weighted estimate: ~1775 Elo.** Tuning showed MCTS @ 400 sims is the sweet spot (~1725 in the quick scan, ~+175 Elo over the best alpha-beta config; 800 sims gave no gain).
+**MLE estimate: ~2075 Elo.** Elo is fit by maximum likelihood over all games (averaging per-level estimates is biased low — saturated easy levels cap at a low value and drag the mean). Search tuning (FPU + `c_puct` + 800 sims) added ~+280 Elo over the untuned MCTS@400 baseline (~1793), with no retraining.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Inference-side overhaul — **~1550 → ~2075 Elo (+~525), no retraining**:
 | **`torch.compile` + CUDA graphs** | alpha-beta forward ~2.3× faster (lossless) |
 | **Batched-leaf MCTS** (virtual loss) | ~8× faster per sim — amortizes the GPU→CPU sync |
 | **Search tuning** — FPU (`fpu=0.2`), `c_puct=1.0`, 800 sims | +~280 Elo (exploitation > exploration; FPU lifts the sims plateau) |
+| **Tree reuse** across moves | re-roots the retained subtree — deeper search at the same per-move cost (won 58% head-to-head) |
 | **Model v2.1** | promoted from `run_021`, now the default weights |
 | **MLE Elo estimator** | per-level averaging was biased low; fit a single Elo over all games |
 
@@ -37,7 +38,7 @@ Tried and rejected: **Stockfish policy distillation** — no gain even at 200k l
 
 Two search engines share the same network (`Pos2MoveV2`):
 
-- **MCTS / PUCT** (`Pos2MoveV2MctsBot`, default) — AlphaZero-style. Policy head → priors, value head → leaf scores, most-visited move chosen. Batched-leaf evaluation with virtual loss amortizes the GPU→CPU sync (~8× faster than single-leaf). Tuned for **exploitation**: first-play-urgency (`fpu=0.2`) and `c_puct=1.0` (flatter priors / more exploration both lost). With FPU the search scales with simulations, so the default is **800 sims**.
+- **MCTS / PUCT** (`Pos2MoveV2MctsBot`, default) — AlphaZero-style. Policy head → priors, value head → leaf scores, most-visited move chosen. Batched-leaf evaluation with virtual loss amortizes the GPU→CPU sync (~8× faster than single-leaf). Tuned for **exploitation**: first-play-urgency (`fpu=0.2`) and `c_puct=1.0` (flatter priors / more exploration both lost). With FPU the search scales with simulations, so the default is **800 sims**. **Tree reuse** re-roots the retained subtree under the moves played (when the caller keeps `board.move_stack`), giving deeper search at the same per-move cost.
 - **Alpha-beta** (`Pos2MoveV2Bot`) — iterative-deepening negamax with quiescence search, policy-prior move ordering, and a Zobrist transposition table.
 
 Both run a `torch.compile`/CUDA-graph forward (~2.3× faster, lossless).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ChessTransformer
 
-A transformer-based chess engine trained on elite Lichess games. The model learns to predict moves directly from board positions, then plays via alpha-beta search guided by its policy and value heads.
+A transformer-based chess engine trained on elite Lichess games. The model learns to predict moves directly from board positions, then plays via an AlphaZero-style MCTS (policy priors + value head), with a compiled alpha-beta engine as an alternative.
 
-**Current strength: ~1550 Elo** (depth-3 alpha-beta vs Stockfish, June 2026)
+**Current strength: ~1775 Elo** (MCTS @ 400 sims, model v2.1, vs Stockfish — 140-game gauntlet over skills 0–12, June 2026)
 
 ## Architecture — Pos2MoveV2
 
@@ -14,17 +14,32 @@ A transformer-based chess engine trained on elite Lichess games. The model learn
 | Policy head | AlphaZero-style 64×73 action planes |
 | Value head | Board state → scalar in (−1, 1) |
 | Training | Muon + AdamW mixed optimizer, BF16, stochastic depth |
-| Search | Iterative-deepening alpha-beta, nucleus filtering (top-p), transposition table |
+| Search (default) | **MCTS / PUCT** — policy priors + value head, batched-leaf evaluation with virtual loss |
+| Search (alt) | Iterative-deepening alpha-beta with quiescence, nucleus filtering (top-p), transposition table |
+| Inference | `torch.compile` + CUDA graphs, bucketed batches, BF16 |
+
+## Search engines
+
+Two search engines share the same network (`Pos2MoveV2`):
+
+- **MCTS / PUCT** (`Pos2MoveV2MctsBot`, default) — AlphaZero-style. Uses the policy head as priors and the value head at leaves; picks the most-visited move. Batched-leaf evaluation with virtual loss collects several leaves per network call, amortizing the GPU→CPU sync (~8× faster than single-leaf). Beat the alpha-beta engine ~82% head-to-head.
+- **Alpha-beta** (`Pos2MoveV2Bot`) — iterative-deepening negamax with quiescence search, policy-prior move ordering, and a Zobrist transposition table.
+
+Both run a `torch.compile`/CUDA-graph forward (~2.3× faster, lossless).
 
 ## Elo Evaluation
 
-| Stockfish skill | Approx. Elo | Result |
-|---|---|---|
-| ≤ 2 | ≤ 1000 | 100% win rate |
-| 7 | ~1600 | ~50 / 50 |
-| 8 | ~1700 | Heavy losses |
+MCTS @ 400 sims, model v2.1, 20 games/level vs Stockfish (`scripts/tune_vs_stockfish.py`):
 
-Evaluated with `scripts/elo_gauntlet.py` over 100 games across skills 0–10.
+| Stockfish skill | Approx. Elo | Score |
+|---|---|---|
+| 0–4 | ≤ 1200 | 95–100% |
+| 6 | ~1500 | 70% |
+| 8 | ~1700 | 62.5% |
+| 10 | ~1900 | 40% |
+| 12 | ~2100 | 27.5% |
+
+**Weighted estimate: ~1775 Elo.** Tuning showed MCTS @ 400 sims is the sweet spot (~1725 in the quick scan, ~+175 Elo over the best alpha-beta config; 800 sims gave no gain).
 
 ## Quick Start
 
@@ -70,7 +85,9 @@ npm run dev
 
 | Variable | Default | Description |
 |---|---|---|
-| `MODEL_PATH` | `data/models/pos2move_v2` | Path to a checkpoint directory |
+| `MODEL_PATH` | `data/models/pos2move_v2.1` | Path to a checkpoint directory |
+| `ENGINE` | `mcts` | Search engine: `mcts` or `alphabeta` |
+| `MCTS_SIMS` | `400` | MCTS simulations per move (when `ENGINE=mcts`) |
 | `ALLOWED_ORIGINS` | `*` | Comma-separated CORS origins |
 
 ## Training
@@ -95,12 +112,23 @@ uv run src/chesstransformer/trainers/pos2move_v2_trainer.py
 ### Evaluate
 
 ```bash
-# Elo gauntlet vs Stockfish
-uv run scripts/elo_gauntlet.py data/models/pos2move_v2 \
+# Tune & benchmark search budget vs Stockfish (alpha-beta depths + MCTS sims)
+uv run scripts/tune_vs_stockfish.py data/models/pos2move_v2.1 \
+    --games 8 --skills 0 2 4 6 8
+
+# Alpha-beta-only Elo gauntlet vs Stockfish
+uv run scripts/elo_gauntlet.py data/models/pos2move_v2.1 \
     --depth 3 --games 10 --skills 0 2 4 6 7 8
 
+# Deterministic engine-vs-engine A/B (MCTS vs alpha-beta, model A vs model B, ...)
+uv run scripts/engine_match.py --a-mcts --a-sims 400 --b-quiescence 4 --b-depth 3
+
+# Inference speed + lossless-regression guard
+uv run scripts/bench_inference.py --depth 3 --save-golden golden.json
+uv run scripts/bench_inference.py --depth 3 --check golden.json
+
 # Export to ONNX (for TensorRT)
-uv run scripts/export_onnx.py data/models/pos2move_v2
+uv run scripts/export_onnx.py data/models/pos2move_v2.1
 ```
 
 ## Project Structure
@@ -113,16 +141,22 @@ ChessTransformer/
 ├── frontend/                         # Next.js web app (human vs bot)
 │   └── app/components/ChessGame.tsx  # Main game component
 ├── data/
-│   └── models/pos2move_v2/           # Bundled model weights
+│   └── models/
+│       ├── pos2move_v2.1/            # Bundled model weights (default)
+│       └── pos2move_v2/              # Previous weights (fallback)
 ├── scripts/
-│   ├── elo_gauntlet.py               # Elo estimation vs Stockfish
+│   ├── tune_vs_stockfish.py          # Sweep alpha-beta depth / MCTS sims vs Stockfish
+│   ├── elo_gauntlet.py               # Elo estimation vs Stockfish (alpha-beta)
+│   ├── engine_match.py               # Deterministic engine-vs-engine A/B
+│   ├── bench_inference.py            # Inference speed + lossless-regression guard
 │   ├── export_onnx.py                # ONNX export for TensorRT
 │   ├── quantize_onnx.py              # INT8 quantization
 │   ├── dataset_sanity_check.py       # Dataset distribution analysis
 │   └── compress_pgn_to_zst.py        # PGN compression utility
 ├── src/chesstransformer/
 │   ├── bots/
-│   │   ├── pos2move_v2_bot.py        # Alpha-beta bot (main)
+│   │   ├── pos2move_v2_mcts_bot.py   # MCTS / PUCT bot (default)
+│   │   ├── pos2move_v2_bot.py        # Alpha-beta bot (with quiescence + compile)
 │   │   └── random_bot.py
 │   ├── models/
 │   │   ├── transformer/pos2move_v2.py  # Model architecture

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A transformer-based chess engine trained on elite Lichess games. The model learns to predict moves directly from board positions, then plays via an AlphaZero-style MCTS (policy priors + value head), with a compiled alpha-beta engine as an alternative.
 
-**Current strength: ~2075 Elo** (MCTS @ 800 sims with FPU + tuned c_puct, model v2.1, vs Stockfish — MLE estimate over a 140-game gauntlet, skills 0–12, June 2026)
+**Current strength: ~2100 Elo** (MCTS @ 800 sims with FPU + tuned c_puct + tree reuse, model v2.1, vs Stockfish — MLE estimate over a 140-game gauntlet, skills 0–12, June 2026)
 
 ## Improvements (June 2026)
 
-Inference-side overhaul — **~1550 → ~2075 Elo (+~525), no retraining**:
+Inference-side overhaul — **~1550 → ~2100 Elo (+~550), no retraining**:
 
 | Change | Effect |
 |---|---|
@@ -45,17 +45,16 @@ Both run a `torch.compile`/CUDA-graph forward (~2.3× faster, lossless).
 
 ## Elo Evaluation
 
-MCTS @ 800 sims (`c_puct=1.0`, `fpu=0.2`), model v2.1, 20 games/level vs Stockfish (`scripts/tune_vs_stockfish.py`):
+MCTS @ 800 sims (`c_puct=1.0`, `fpu=0.2`, tree reuse), model v2.1, 20 games/level vs Stockfish (`scripts/tune_vs_stockfish.py`):
 
 | Stockfish skill | Approx. Elo | Score |
 |---|---|---|
-| 0–4 | ≤ 1200 | 100% |
-| 6 | ~1500 | 97.5% |
-| 8 | ~1700 | 100% |
-| 10 | ~1900 | 62.5% |
-| 12 | ~2100 | 47.5% |
+| 0–6 | ≤ 1500 | 100% |
+| 8 | ~1700 | 90% |
+| 10 | ~1900 | 85% |
+| 12 | ~2100 | 35% |
 
-**MLE estimate: ~2075 Elo.** Elo is fit by maximum likelihood over all games (averaging per-level estimates is biased low — saturated easy levels cap at a low value and drag the mean). Search tuning (FPU + `c_puct` + 800 sims) added ~+280 Elo over the untuned MCTS@400 baseline (~1793), with no retraining.
+**MLE estimate: ~2100 Elo.** Elo is fit by maximum likelihood over all games (averaging per-level estimates is biased low — saturated easy levels cap at a low value and drag the mean). Search tuning (FPU + `c_puct` + 800 sims) added ~+280 Elo over the untuned MCTS@400 baseline (~1793), and tree reuse a further small gain — all with no retraining. (Per-level scores carry ~20-game noise; the MLE smooths it.)
 
 ## Quick Start
 
@@ -103,7 +102,7 @@ npm run dev
 |---|---|---|
 | `MODEL_PATH` | `data/models/pos2move_v2.1` | Path to a checkpoint directory |
 | `ENGINE` | `mcts` | Search engine: `mcts` or `alphabeta` |
-| `MCTS_SIMS` | `400` | MCTS simulations per move (when `ENGINE=mcts`) |
+| `MCTS_SIMS` | `800` | MCTS simulations per move (when `ENGINE=mcts`) |
 | `ALLOWED_ORIGINS` | `*` | Comma-separated CORS origins |
 
 ## Training

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ A transformer-based chess engine trained on elite Lichess games. The model learn
 
 **Current strength: ~2075 Elo** (MCTS @ 800 sims with FPU + tuned c_puct, model v2.1, vs Stockfish — MLE estimate over a 140-game gauntlet, skills 0–12, June 2026)
 
+## Improvements (June 2026)
+
+Inference-side overhaul — **~1550 → ~2075 Elo (+~525), no retraining**:
+
+| Change | Effect |
+|---|---|
+| **MCTS / PUCT engine** (new default) | beat the alpha-beta engine ~82% head-to-head |
+| **`torch.compile` + CUDA graphs** | alpha-beta forward ~2.3× faster (lossless) |
+| **Batched-leaf MCTS** (virtual loss) | ~8× faster per sim — amortizes the GPU→CPU sync |
+| **Search tuning** — FPU (`fpu=0.2`), `c_puct=1.0`, 800 sims | +~280 Elo (exploitation > exploration; FPU lifts the sims plateau) |
+| **Model v2.1** | promoted from `run_021`, now the default weights |
+| **MLE Elo estimator** | per-level averaging was biased low; fit a single Elo over all games |
+
+Tried and rejected: **Stockfish policy distillation** — no gain even at 200k labels (the policy is near the 11.7M model's capacity ceiling).
+
 ## Architecture — Pos2MoveV2
 
 | Component | Details |

--- a/backend/api.py
+++ b/backend/api.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 import chess
 import os
 
-from chesstransformer.bots import Pos2MoveV2Bot, RandomBot
+from chesstransformer.bots import Pos2MoveV2Bot, Pos2MoveV2MctsBot, RandomBot
 
 app = FastAPI(title="ChessTransformer API")
 
@@ -24,16 +24,24 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Set MODEL_PATH env var to point to a specific checkpoint directory
+# Set MODEL_PATH env var to point to a specific checkpoint directory.
+# ENGINE selects the search: "mcts" (default, strongest — won 82% head-to-head
+# vs the alpha-beta engine) or "alphabeta". MCTS_SIMS tunes MCTS strength/speed.
 model_path = os.environ.get("MODEL_PATH")
+engine = os.environ.get("ENGINE", "mcts").lower()
 try:
     kwargs = {}
     if model_path:
         kwargs["model_dir"] = model_path
-    bot = Pos2MoveV2Bot(**kwargs)
-    bot_type = "Pos2MoveV2Bot"
+    if engine == "alphabeta":
+        bot = Pos2MoveV2Bot(**kwargs)
+        bot_type = "Pos2MoveV2Bot (alpha-beta)"
+    else:
+        kwargs["num_simulations"] = int(os.environ.get("MCTS_SIMS", "400"))
+        bot = Pos2MoveV2MctsBot(**kwargs)
+        bot_type = "Pos2MoveV2MctsBot (MCTS)"
 except Exception as e:
-    print(f"Warning: Could not load Pos2MoveV2Bot: {e}")
+    print(f"Warning: Could not load Pos2MoveV2 bot: {e}")
     print("Falling back to RandomBot")
     bot = RandomBot()
     bot_type = "RandomBot"

--- a/backend/api.py
+++ b/backend/api.py
@@ -37,7 +37,7 @@ try:
         bot = Pos2MoveV2Bot(**kwargs)
         bot_type = "Pos2MoveV2Bot (alpha-beta)"
     else:
-        kwargs["num_simulations"] = int(os.environ.get("MCTS_SIMS", "400"))
+        kwargs["num_simulations"] = int(os.environ.get("MCTS_SIMS", "800"))
         bot = Pos2MoveV2MctsBot(**kwargs)
         bot_type = "Pos2MoveV2MctsBot (MCTS)"
 except Exception as e:

--- a/backend/api.py
+++ b/backend/api.py
@@ -29,6 +29,7 @@ app.add_middleware(
 # vs the alpha-beta engine) or "alphabeta". MCTS_SIMS tunes MCTS strength/speed.
 model_path = os.environ.get("MODEL_PATH")
 engine = os.environ.get("ENGINE", "mcts").lower()
+engine_info = {"engine": "none", "model": None, "sims": None, "approx_elo": None}
 try:
     kwargs = {}
     if model_path:
@@ -36,15 +37,44 @@ try:
     if engine == "alphabeta":
         bot = Pos2MoveV2Bot(**kwargs)
         bot_type = "Pos2MoveV2Bot (alpha-beta)"
+        engine_info.update(engine="alpha-beta", approx_elo=1550)
     else:
-        kwargs["num_simulations"] = int(os.environ.get("MCTS_SIMS", "800"))
+        sims = int(os.environ.get("MCTS_SIMS", "800"))
+        kwargs["num_simulations"] = sims
         bot = Pos2MoveV2MctsBot(**kwargs)
         bot_type = "Pos2MoveV2MctsBot (MCTS)"
+        engine_info.update(engine="mcts", sims=sims, approx_elo=2100)
+    engine_info["model"] = os.path.basename(os.path.normpath(model_path)) if model_path else "pos2move_v2.1"
 except Exception as e:
     print(f"Warning: Could not load Pos2MoveV2 bot: {e}")
     print("Falling back to RandomBot")
     bot = RandomBot()
     bot_type = "RandomBot"
+
+
+# The API is otherwise stateless (each request carries a FEN, which has no move
+# history). We keep one persistent game board so the MCTS engine receives full
+# move history and its tree-reuse stays active across moves. A single-game demo:
+# concurrent games simply fall back to a fresh (history-less) tree, which is safe.
+_session_board: chess.Board | None = None
+
+
+def _resolve_board(fen: str) -> chess.Board:
+    """Board at ``fen`` carrying its move history when possible (so MCTS can reuse
+    its search tree). Infers the opponent's last move from the retained session
+    board; falls back to a history-less board on mismatch / new game."""
+    global _session_board
+    key = fen.split(" ")[:4]  # piece placement, turn, castling, ep (ignore clocks)
+    prev = _session_board
+    if prev is not None:
+        if prev.fen().split(" ")[:4] == key:
+            return prev
+        for mv in list(prev.legal_moves):
+            prev.push(mv)
+            if prev.fen().split(" ")[:4] == key:
+                return prev  # found the move that reached `fen`; history intact
+            prev.pop()
+    return chess.Board(fen)  # new game / out of sync -> fresh, no reuse this move
 
 
 # Pydantic models for request/response validation
@@ -60,6 +90,10 @@ class ValidateMoveRequest(BaseModel):
 class HealthResponse(BaseModel):
     status: str
     bot_type: str
+    engine: str | None = None
+    model: str | None = None
+    sims: int | None = None
+    approx_elo: int | None = None
 
 
 class EvalRequest(BaseModel):
@@ -94,8 +128,8 @@ class ValidateMoveResponse(BaseModel):
 
 @app.get("/api/health", response_model=HealthResponse)
 async def health():
-    """Health check endpoint."""
-    return HealthResponse(status="ok", bot_type=bot_type)
+    """Health check endpoint (also reports the active engine for display)."""
+    return HealthResponse(status="ok", bot_type=bot_type, **engine_info)
 
 
 @app.post("/api/move", response_model=MoveResponse)
@@ -118,7 +152,7 @@ async def get_bot_move(request: MoveRequest):
     }
     """
     try:
-        board = chess.Board(request.fen)
+        board = _resolve_board(request.fen)  # carries move history -> MCTS tree reuse
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid FEN string")
 
@@ -133,6 +167,9 @@ async def get_bot_move(request: MoveRequest):
             value = bot.get_value(board)
 
         board.push_uci(move_uci)
+        # Persist with the bot's move applied so the next request can extend it.
+        global _session_board
+        _session_board = board
 
         return MoveResponse(
             move=move_uci,
@@ -156,6 +193,8 @@ async def new_game():
 
     Returns the initial board state.
     """
+    global _session_board
+    _session_board = None  # drop any retained search tree / history from prior game
     board = chess.Board()
     return NewGameResponse(fen=board.fen(), game_over=False)
 

--- a/data/models/pos2move_v2.1/model.safetensors
+++ b/data/models/pos2move_v2.1/model.safetensors
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:732158f7144cf7a09059add087ac3ee3cbdede94b01cdd04a518b7df11fdadfa
+size 46631616

--- a/data/models/pos2move_v2.1/model_config.json
+++ b/data/models/pos2move_v2.1/model_config.json
@@ -1,0 +1,9 @@
+{
+  "vocab_size": 13,
+  "embed_dim": 256,
+  "nb_transformer_layers": 16,
+  "num_heads": 8,
+  "dropout": 0.05,
+  "kvq_bias": false,
+  "layer_drop": 0.1
+}

--- a/frontend/app/components/ChessGame.tsx
+++ b/frontend/app/components/ChessGame.tsx
@@ -70,6 +70,7 @@ export default function ChessGame() {
   const [gameStatus, setGameStatus] = useState<string>('White to move');
   const [isThinking, setIsThinking] = useState(false);
   const [botType, setBotType] = useState<string>('Loading...');
+  const [engineLabel, setEngineLabel] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [playerColor, setPlayerColor] = useState<'w' | 'b'>('w');
   const [gameStarted, setGameStarted] = useState(false);
@@ -87,7 +88,16 @@ export default function ChessGame() {
     const poll = (attempt: number) => {
       fetch(`${API_BASE_URL}/api/health`)
         .then(res => res.json())
-        .then(data => { if (!cancelled) setBotType(data.bot_type); })
+        .then(data => {
+          if (cancelled) return;
+          setBotType(data.bot_type);
+          if (data.engine && data.engine !== 'none') {
+            const search = data.engine === 'mcts' ? `MCTS ${data.sims} sims` : data.engine;
+            const parts = [data.model, search];
+            if (data.approx_elo) parts.push(`~${data.approx_elo} Elo`);
+            setEngineLabel(parts.filter(Boolean).join(' · '));
+          }
+        })
         .catch(() => {
           if (cancelled) return;
           if (attempt < 20) {
@@ -466,6 +476,9 @@ export default function ChessGame() {
                 <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
               </span>
               <span className="text-emerald-100 font-medium">{botType}</span>
+              {engineLabel && (
+                <span className="text-emerald-300/70 text-sm border-l border-white/10 pl-3">{engineLabel}</span>
+              )}
             </div>
           </div>
 

--- a/scripts/bench_inference.py
+++ b/scripts/bench_inference.py
@@ -1,0 +1,204 @@
+"""Inference microbenchmark + lossless-regression guard for Pos2MoveV2Bot.
+
+Runs the bot over a fixed suite of positions at a *fixed depth with no time
+limit* (so the search is fully deterministic) and reports throughput:
+
+  - mean time / move
+  - nodes / sec (alpha-beta nodes)
+  - forward calls / sec (approximated by unique positions evaluated = tt misses)
+
+It also records the move chosen per position. Use ``--save-golden`` once to
+capture a reference, then ``--check golden.json`` after any *lossless* change
+(Track A) to assert the engine still picks the exact same moves.
+
+Usage
+-----
+    # Baseline: capture golden moves + speed
+    uv run python scripts/bench_inference.py data/models/pos2move_v2 \
+        --depth 3 --save-golden bench_golden.json
+
+    # After a lossless change: confirm identical moves + see speed delta
+    uv run python scripts/bench_inference.py data/models/pos2move_v2 \
+        --depth 3 --check bench_golden.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import chess
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from chesstransformer.bots.pos2move_v2_bot import Pos2MoveV2Bot
+
+# Fixed suite spanning openings, middlegames, tactics and endgames so the
+# benchmark exercises a representative range of branching factors.
+POSITIONS: list[str] = [
+    # Start position
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    # Open Italian middlegame
+    "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3",
+    # Sicilian Najdorf
+    "rnbqkb1r/1p2pppp/p2p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 6",
+    # Queen's Gambit Declined
+    "rnbqkb1r/ppp2ppp/4pn2/3p4/2PP4/2N2N2/PP2PPPP/R1BQKB1R w KQkq - 0 5",
+    # Tactical middlegame (many captures available)
+    "r2q1rk1/pp1bbppp/2n1pn2/2pp4/3P1B2/2PBPN2/PP1N1PPP/R2Q1RK1 w - - 0 10",
+    # Sharp King's Indian-style centre
+    "r1bq1rk1/ppp2ppp/2np1n2/2b1p3/2B1P3/2NP1N2/PPP2PPP/R1BQ1RK1 w - - 0 7",
+    # Rook + pawn endgame
+    "8/5pk1/6p1/8/8/1R4P1/5PK1/r7 w - - 0 40",
+    # King and pawn endgame
+    "8/8/4k3/8/4P3/4K3/8/8 w - - 0 50",
+    # Queen endgame
+    "8/8/4k3/8/8/3QK3/8/8 w - - 0 60",
+    # Complex middlegame with castling rights
+    "r3k2r/pppq1ppp/2np1n2/2b1p1B1/2B1P1b1/2NP1N2/PPPQ1PPP/R3K2R w KQkq - 0 9",
+]
+
+
+def run_suite(bot: Pos2MoveV2Bot) -> tuple[list[dict], dict]:
+    """Run the bot over the fixed suite. Returns (per-position records, totals)."""
+    records: list[dict] = []
+    total_time = 0.0
+    total_nodes = 0
+    total_misses = 0  # unique positions actually forwarded through the model
+
+    for fen in POSITIONS:
+        board = chess.Board(fen)
+        # tt is shared across calls; misses for *this* call = evals - tt_hits.
+        # We clear the tt per position so the count reflects a single search.
+        bot._tt.clear()
+        t0 = time.perf_counter()
+        move, value = bot.predict(board)
+        elapsed = time.perf_counter() - t0
+
+        misses = len(bot._tt)  # distinct positions evaluated this search
+        total_time += elapsed
+        total_nodes += bot.nodes_searched
+        total_misses += misses
+
+        records.append(
+            {
+                "fen": fen,
+                "move": move,
+                "value": round(float(value), 4),
+                "completed_depth": bot.completed_depth,
+                "nodes": bot.nodes_searched,
+                "forward_evals": misses,
+                "tt_hits": bot.tt_hits,
+                "time_s": round(elapsed, 4),
+            }
+        )
+
+    n = len(POSITIONS)
+    totals = {
+        "positions": n,
+        "total_time_s": round(total_time, 3),
+        "mean_time_per_move_s": round(total_time / n, 4),
+        "total_nodes": total_nodes,
+        "nodes_per_sec": round(total_nodes / total_time, 1) if total_time else 0.0,
+        "total_forward_evals": total_misses,
+        "forward_evals_per_sec": round(total_misses / total_time, 1) if total_time else 0.0,
+    }
+    return records, totals
+
+
+def print_totals(totals: dict):
+    print("\n" + "=" * 56)
+    print("INFERENCE BENCHMARK")
+    print("=" * 56)
+    print(f"  positions:            {totals['positions']}")
+    print(f"  total time:           {totals['total_time_s']:.3f} s")
+    print(f"  mean time / move:     {totals['mean_time_per_move_s'] * 1000:.1f} ms")
+    print(f"  alpha-beta nodes:     {totals['total_nodes']}")
+    print(f"  nodes / sec:          {totals['nodes_per_sec']:.0f}")
+    print(f"  forward evals:        {totals['total_forward_evals']}")
+    print(f"  forward evals / sec:  {totals['forward_evals_per_sec']:.0f}")
+    print("=" * 56)
+
+
+def check_against_golden(records: list[dict], golden_path: Path) -> bool:
+    with open(golden_path) as f:
+        golden = json.load(f)
+    g_records = {r["fen"]: r for r in golden["records"]}
+
+    ok = True
+    print("\nLOSSLESS REGRESSION CHECK (moves must match golden)")
+    print("-" * 56)
+    for r in records:
+        g = g_records.get(r["fen"])
+        if g is None:
+            print(f"  ?  {r['fen'][:30]}…  (no golden entry)")
+            ok = False
+            continue
+        move_match = r["move"] == g["move"]
+        # Value drift is expected under compile numerics; report but don't fail.
+        vdrift = abs(r["value"] - g["value"])
+        status = "OK " if move_match else "MISMATCH"
+        if not move_match:
+            ok = False
+        line = f"  {status}  {g['move']}"
+        if not move_match:
+            line += f" -> {r['move']}"
+        if vdrift > 1e-3:
+            line += f"  (value drift {vdrift:.4f})"
+        print(line)
+    print("-" * 56)
+    print("RESULT:", "PASS — moves identical" if ok else "FAIL — move(s) changed")
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "model_dir",
+        nargs="?",
+        default=str(Path(__file__).resolve().parents[1] / "data" / "models" / "pos2move_v2"),
+    )
+    parser.add_argument("--depth", type=int, default=3)
+    parser.add_argument("--top-p", type=float, default=0.90)
+    parser.add_argument("--ema", action="store_true")
+    parser.add_argument("--device", default=None, help="Override device (cuda/cpu)")
+    parser.add_argument("--warmup-runs", type=int, default=1,
+                        help="Full suite warmup passes before timing (default 1)")
+    parser.add_argument("--save-golden", default=None, help="Write reference JSON here")
+    parser.add_argument("--check", default=None, help="Compare moves against this golden JSON")
+    args = parser.parse_args()
+
+    kwargs = dict(
+        model_dir=args.model_dir,
+        depth=args.depth,
+        top_p=args.top_p,
+        time_limit=0.0,  # no time limit -> deterministic fixed-depth search
+        use_ema=args.ema,
+    )
+    if args.device:
+        kwargs["device"] = args.device
+    bot = Pos2MoveV2Bot(**kwargs)
+
+    # Warmup: torch.compile / CUDA graphs / cudnn autotune happen on first runs.
+    for _ in range(max(0, args.warmup_runs)):
+        run_suite(bot)
+
+    records, totals = run_suite(bot)
+    print_totals(totals)
+
+    if args.save_golden:
+        out = Path(args.save_golden)
+        with open(out, "w") as f:
+            json.dump({"totals": totals, "records": records}, f, indent=2)
+        print(f"\nGolden reference saved to {out}")
+
+    if args.check:
+        ok = check_against_golden(records, Path(args.check))
+        sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/engine_match.py
+++ b/scripts/engine_match.py
@@ -81,12 +81,16 @@ def play(white: Pos2MoveV2Bot, black: Pos2MoveV2Bot, start_fen: str, max_moves: 
     return result, n_moves, nodes, move_time
 
 
-def build_bot(args, ema: bool, quiescence: int, depth: int, mcts: bool, sims: int, model_dir: str):
+def build_bot(args, ema, quiescence, depth, mcts, sims, model_dir,
+              cpuct=1.5, prior_temp=1.0, fpu=None):
     if mcts:
         return Pos2MoveV2MctsBot(
             model_dir=model_dir,
             num_simulations=sims,
             sim_batch=args.sim_batch,
+            c_puct=cpuct,
+            prior_temp=prior_temp,
+            fpu=fpu,
             time_limit=args.time_limit,
             use_ema=ema,
             compile=not args.no_compile,
@@ -121,6 +125,12 @@ def main():
     p.add_argument("--a-sims", type=int, default=200)
     p.add_argument("--b-sims", type=int, default=200)
     p.add_argument("--sim-batch", type=int, default=16, help="MCTS leaves per batch")
+    p.add_argument("--a-cpuct", type=float, default=1.5)
+    p.add_argument("--b-cpuct", type=float, default=1.5)
+    p.add_argument("--a-prior-temp", type=float, default=1.0)
+    p.add_argument("--b-prior-temp", type=float, default=1.0)
+    p.add_argument("--a-fpu", type=float, default=None)
+    p.add_argument("--b-fpu", type=float, default=None)
     p.add_argument("--a-model-dir", default=None, help="Override model dir for engine A")
     p.add_argument("--b-model-dir", default=None, help="Override model dir for engine B")
     p.add_argument("--openings", type=int, default=len(OPENINGS), help="How many openings to use")
@@ -131,12 +141,16 @@ def main():
     b_depth = args.b_depth if args.b_depth is not None else args.depth
     a_model = args.a_model_dir or args.model_dir
     b_model = args.b_model_dir or args.model_dir
-    a_desc = f"MCTS sims={args.a_sims}" if args.a_mcts else f"depth={a_depth} quiescence={args.a_quiescence}"
-    b_desc = f"MCTS sims={args.b_sims}" if args.b_mcts else f"depth={b_depth} quiescence={args.b_quiescence}"
+    a_desc = (f"MCTS sims={args.a_sims} cpuct={args.a_cpuct} ptemp={args.a_prior_temp} fpu={args.a_fpu}"
+              if args.a_mcts else f"depth={a_depth} quiescence={args.a_quiescence}")
+    b_desc = (f"MCTS sims={args.b_sims} cpuct={args.b_cpuct} ptemp={args.b_prior_temp} fpu={args.b_fpu}"
+              if args.b_mcts else f"depth={b_depth} quiescence={args.b_quiescence}")
     print(f"Engine A: {a_desc} ema={args.a_ema} model={a_model}")
     print(f"Engine B: {b_desc} ema={args.b_ema} model={b_model}")
-    bot_a = build_bot(args, args.a_ema, args.a_quiescence, a_depth, args.a_mcts, args.a_sims, a_model)
-    bot_b = build_bot(args, args.b_ema, args.b_quiescence, b_depth, args.b_mcts, args.b_sims, b_model)
+    bot_a = build_bot(args, args.a_ema, args.a_quiescence, a_depth, args.a_mcts, args.a_sims, a_model,
+                      args.a_cpuct, args.a_prior_temp, args.a_fpu)
+    bot_b = build_bot(args, args.b_ema, args.b_quiescence, b_depth, args.b_mcts, args.b_sims, b_model,
+                      args.b_cpuct, args.b_prior_temp, args.b_fpu)
 
     openings = OPENINGS[: args.openings]
     a_score = 0.0

--- a/scripts/engine_match.py
+++ b/scripts/engine_match.py
@@ -82,7 +82,7 @@ def play(white: Pos2MoveV2Bot, black: Pos2MoveV2Bot, start_fen: str, max_moves: 
 
 
 def build_bot(args, ema, quiescence, depth, mcts, sims, model_dir,
-              cpuct=1.5, prior_temp=1.0, fpu=None):
+              cpuct=1.5, prior_temp=1.0, fpu=None, tree_reuse=True):
     if mcts:
         return Pos2MoveV2MctsBot(
             model_dir=model_dir,
@@ -91,6 +91,7 @@ def build_bot(args, ema, quiescence, depth, mcts, sims, model_dir,
             c_puct=cpuct,
             prior_temp=prior_temp,
             fpu=fpu,
+            tree_reuse=tree_reuse,
             time_limit=args.time_limit,
             use_ema=ema,
             compile=not args.no_compile,
@@ -131,6 +132,8 @@ def main():
     p.add_argument("--b-prior-temp", type=float, default=1.0)
     p.add_argument("--a-fpu", type=float, default=None)
     p.add_argument("--b-fpu", type=float, default=None)
+    p.add_argument("--a-no-reuse", action="store_true", help="disable tree reuse for engine A")
+    p.add_argument("--b-no-reuse", action="store_true", help="disable tree reuse for engine B")
     p.add_argument("--a-model-dir", default=None, help="Override model dir for engine A")
     p.add_argument("--b-model-dir", default=None, help="Override model dir for engine B")
     p.add_argument("--openings", type=int, default=len(OPENINGS), help="How many openings to use")
@@ -148,9 +151,9 @@ def main():
     print(f"Engine A: {a_desc} ema={args.a_ema} model={a_model}")
     print(f"Engine B: {b_desc} ema={args.b_ema} model={b_model}")
     bot_a = build_bot(args, args.a_ema, args.a_quiescence, a_depth, args.a_mcts, args.a_sims, a_model,
-                      args.a_cpuct, args.a_prior_temp, args.a_fpu)
+                      args.a_cpuct, args.a_prior_temp, args.a_fpu, not args.a_no_reuse)
     bot_b = build_bot(args, args.b_ema, args.b_quiescence, b_depth, args.b_mcts, args.b_sims, b_model,
-                      args.b_cpuct, args.b_prior_temp, args.b_fpu)
+                      args.b_cpuct, args.b_prior_temp, args.b_fpu, not args.b_no_reuse)
 
     openings = OPENINGS[: args.openings]
     a_score = 0.0

--- a/scripts/engine_match.py
+++ b/scripts/engine_match.py
@@ -1,0 +1,179 @@
+"""Deterministic engine-vs-engine match for A/B-testing Pos2MoveV2Bot configs.
+
+Both engines are (essentially) deterministic, so variety comes from a fixed
+suite of opening positions played from both colours. Useful for validating a
+strength change (e.g. quiescence on/off, EMA vs base) much faster and with less
+variance than a Stockfish gauntlet.
+
+Usage
+-----
+    # Quiescence A (qdepth=4) vs B (qdepth=0), same weights:
+    uv run python scripts/engine_match.py --a-quiescence 4 --b-quiescence 0 --depth 3
+
+    # EMA vs base weights:
+    uv run python scripts/engine_match.py --a-ema --b-quiescence 4 --depth 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import chess
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from chesstransformer.bots.pos2move_v2_bot import Pos2MoveV2Bot
+from chesstransformer.bots.pos2move_v2_mcts_bot import Pos2MoveV2MctsBot
+
+# Common openings a few moves in, to diversify otherwise-deterministic play.
+OPENINGS: list[str] = [
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",          # start
+    "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2",     # Sicilian
+    "rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq d6 0 2",     # QP
+    "rnbqkbnr/ppp1pppp/8/3p4/2PP4/8/PP2PPPP/RNBQKBNR b KQkq c3 0 2",     # QGambit
+    "rnbqkb1r/pppppppp/5n2/8/2PP4/8/PP2PPPP/RNBQKBNR b KQkq - 0 2",      # Indian
+    "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 2 2",  # open game
+    "rnbqkb1r/pppppp1p/5np1/8/2PP4/8/PP2PPPP/RNBQKBNR w KQkq - 0 3",     # KID/Gruen
+    "rnbqkbnr/pp2pppp/2p5/3p4/2PP4/8/PP2PPPP/RNBQKBNR w KQkq - 0 3",     # Slav
+    "rnbqkbnr/ppp2ppp/4p3/3p4/2PP4/8/PP2PPPP/RNBQKBNR w KQkq - 0 3",     # QGD
+    "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",  # Sicilian Nc6
+    "rnbqkb1r/pppp1ppp/4pn2/8/2PP4/8/PP2PPPP/RNBQKBNR w KQkq - 0 3",     # Nimzo/QID
+    "rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 2",     # Scandi
+    "r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3", # Ruy Lopez
+    "rnbqkb1r/ppp1pppp/5n2/3p4/2PP4/5N2/PP2PPPP/RNBQKB1R b KQkq - 1 3",  # QGD/Indian
+    "rnbqk2r/ppppppbp/5np1/8/2PP4/2N5/PP2PPPP/R1BQKBNR w KQkq - 2 4",    # KID
+    "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4", # Italian
+    "rnbqkbnr/1ppppppp/p7/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",       # 1.e4 a6
+    "rnbqkbnr/pppppp1p/6p1/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",      # Modern
+    "rnbqkbnr/ppppp1pp/8/5p2/4P3/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 2",     # 1.e4 f5
+    "rnbqkbnr/pp1ppppp/8/2p5/3P4/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 2",     # 1.d4 c5
+    "rnbqkb1r/pppppppp/5n2/8/3P4/5N2/PPP1PPPP/RNBQKB1R b KQkq - 2 2",    # 1.d4 Nf6 2.Nf3
+    "rnbqkbnr/pp1ppppp/8/2p5/4P3/2N5/PPPP1PPP/R1BQKBNR b KQkq - 1 2",    # closed Sicilian
+    "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/2N5/PPPP1PPP/R1BQK1NR w KQkq - 4 4", # 4 knights-ish
+    "rnbqkb1r/ppp1pppp/5n2/3p4/3P1B2/8/PPP1PPPP/RN1QKBNR b KQkq - 2 3",  # London
+]
+
+
+def play(white: Pos2MoveV2Bot, black: Pos2MoveV2Bot, start_fen: str, max_moves: int):
+    board = chess.Board(start_fen)
+    nodes = 0
+    move_time = 0.0
+    n_moves = 0
+    while board.fullmove_number <= max_moves:
+        if not any(board.legal_moves) or board.is_insufficient_material() \
+                or board.is_repetition(3) or board.halfmove_clock >= 100:
+            break
+        bot = white if board.turn == chess.WHITE else black
+        t0 = time.perf_counter()
+        mv, _ = bot.predict(board)
+        move_time += time.perf_counter() - t0
+        nodes += bot.nodes_searched
+        n_moves += 1
+        board.push_uci(mv)
+
+    if not any(board.legal_moves) and board.is_check():
+        result = "0-1" if board.turn == chess.WHITE else "1-0"
+    else:
+        result = "1/2-1/2"
+    return result, n_moves, nodes, move_time
+
+
+def build_bot(args, ema: bool, quiescence: int, depth: int, mcts: bool, sims: int, model_dir: str):
+    if mcts:
+        return Pos2MoveV2MctsBot(
+            model_dir=model_dir,
+            num_simulations=sims,
+            sim_batch=args.sim_batch,
+            time_limit=args.time_limit,
+            use_ema=ema,
+            compile=not args.no_compile,
+        )
+    return Pos2MoveV2Bot(
+        model_dir=model_dir,
+        depth=depth,
+        top_p=args.top_p,
+        time_limit=args.time_limit,
+        use_ema=ema,
+        quiescence_depth=quiescence,
+        compile=not args.no_compile,
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("model_dir", nargs="?",
+                   default=str(Path(__file__).resolve().parents[1] / "data" / "models" / "pos2move_v2"))
+    p.add_argument("--depth", type=int, default=3, help="Shared depth if --a-depth/--b-depth unset")
+    p.add_argument("--a-depth", type=int, default=None)
+    p.add_argument("--b-depth", type=int, default=None)
+    p.add_argument("--top-p", type=float, default=0.90)
+    p.add_argument("--time-limit", type=float, default=0.0, help="0 = fixed depth (deterministic)")
+    p.add_argument("--max-moves", type=int, default=120)
+    p.add_argument("--a-ema", action="store_true")
+    p.add_argument("--b-ema", action="store_true")
+    p.add_argument("--a-quiescence", type=int, default=4)
+    p.add_argument("--b-quiescence", type=int, default=0)
+    p.add_argument("--a-mcts", action="store_true", help="Engine A uses MCTS/PUCT")
+    p.add_argument("--b-mcts", action="store_true", help="Engine B uses MCTS/PUCT")
+    p.add_argument("--a-sims", type=int, default=200)
+    p.add_argument("--b-sims", type=int, default=200)
+    p.add_argument("--sim-batch", type=int, default=16, help="MCTS leaves per batch")
+    p.add_argument("--a-model-dir", default=None, help="Override model dir for engine A")
+    p.add_argument("--b-model-dir", default=None, help="Override model dir for engine B")
+    p.add_argument("--openings", type=int, default=len(OPENINGS), help="How many openings to use")
+    p.add_argument("--no-compile", action="store_true")
+    args = p.parse_args()
+
+    a_depth = args.a_depth if args.a_depth is not None else args.depth
+    b_depth = args.b_depth if args.b_depth is not None else args.depth
+    a_model = args.a_model_dir or args.model_dir
+    b_model = args.b_model_dir or args.model_dir
+    a_desc = f"MCTS sims={args.a_sims}" if args.a_mcts else f"depth={a_depth} quiescence={args.a_quiescence}"
+    b_desc = f"MCTS sims={args.b_sims}" if args.b_mcts else f"depth={b_depth} quiescence={args.b_quiescence}"
+    print(f"Engine A: {a_desc} ema={args.a_ema} model={a_model}")
+    print(f"Engine B: {b_desc} ema={args.b_ema} model={b_model}")
+    bot_a = build_bot(args, args.a_ema, args.a_quiescence, a_depth, args.a_mcts, args.a_sims, a_model)
+    bot_b = build_bot(args, args.b_ema, args.b_quiescence, b_depth, args.b_mcts, args.b_sims, b_model)
+
+    openings = OPENINGS[: args.openings]
+    a_score = 0.0
+    a_w = a_d = a_l = 0
+    a_nodes = a_time = 0.0
+    a_n_moves = 0
+    games = 0
+
+    for fen in openings:
+        # Game 1: A=White, B=Black ; Game 2: A=Black, B=White
+        for a_is_white in (True, False):
+            white, black = (bot_a, bot_b) if a_is_white else (bot_b, bot_a)
+            result, n_moves, nodes, mtime = play(white, black, fen, args.max_moves)
+            games += 1
+            if result == "1/2-1/2":
+                sc = 0.5
+            elif (result == "1-0") == a_is_white:
+                sc = 1.0
+            else:
+                sc = 0.0
+            a_score += sc
+            a_w += sc == 1.0
+            a_d += sc == 0.5
+            a_l += sc == 0.0
+            # Track A's own move cost (half the moves are A's, roughly).
+            a_n_moves += n_moves
+            a_nodes += nodes
+            a_time += mtime
+
+    print("\n" + "=" * 56)
+    print(f"MATCH RESULT (engine A perspective), {games} games")
+    print("=" * 56)
+    print(f"  A: +{a_w} ={a_d} -{a_l}   score {a_score}/{games} = {a_score / games:.1%}")
+    print(f"  total move time: {a_time:.1f}s over {a_n_moves} half-moves "
+          f"({a_time / max(a_n_moves,1) * 1000:.0f} ms/move, {a_nodes / max(a_time,1e-9):.0f} nodes/s)")
+    print("=" * 56)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tune_vs_stockfish.py
+++ b/scripts/tune_vs_stockfish.py
@@ -1,0 +1,101 @@
+"""Tune search budget vs Stockfish: sweep alpha-beta depth and MCTS sims.
+
+Reuses ``elo_gauntlet.run_gauntlet`` to play each engine config against a range
+of Stockfish skill levels and prints an estimated Elo per config so you can pick
+the best strength/time point.
+
+Usage
+-----
+    uv run python scripts/tune_vs_stockfish.py \
+        logs/pos2move_v2/run_021_20260604_130336/checkpoints/best_model \
+        --games 8 --skills 0 2 4 6 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from chesstransformer.bots.pos2move_v2_bot import Pos2MoveV2Bot
+from chesstransformer.bots.pos2move_v2_mcts_bot import Pos2MoveV2MctsBot
+
+# elo_gauntlet lives in the same scripts/ dir.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from elo_gauntlet import run_gauntlet  # noqa: E402
+
+
+def weighted_elo(results: list[dict]) -> float | None:
+    """Replicates elo_gauntlet's weighting: matchups nearer 50% count more."""
+    ests, ws = [], []
+    for r in results:
+        if r.get("est_elo") is None:
+            continue
+        total = r["wins"] + r["draws"] + r["losses"]
+        closeness = 1.0 - abs(r["score"] - 0.5) * 2
+        ests.append(r["est_elo"])
+        ws.append(total * max(closeness, 0.1))
+    if not ests:
+        return None
+    return sum(e * w for e, w in zip(ests, ws)) / sum(ws)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("model_dir", help="Model dir (e.g. run21 best_model)")
+    p.add_argument("--games", type=int, default=8, help="Games per skill level")
+    p.add_argument("--skills", type=int, nargs="+", default=[0, 2, 4, 6, 8])
+    p.add_argument("--sf-path", default="/usr/games/stockfish")
+    p.add_argument("--sf-time", type=float, default=0.1)
+    p.add_argument("--ab-depths", type=int, nargs="*", default=[2, 3, 4])
+    p.add_argument("--mcts-sims", type=int, nargs="*", default=[200, 400, 800])
+    p.add_argument("--sim-batch", type=int, default=16)
+    p.add_argument("--ema", action="store_true")
+    args = p.parse_args()
+
+    # (label, factory) — built lazily so a failure in one doesn't block others.
+    configs: list[tuple[str, callable]] = []
+    for d in args.ab_depths:
+        configs.append((
+            f"alphabeta d={d} q=4",
+            lambda d=d: Pos2MoveV2Bot(model_dir=args.model_dir, depth=d, quiescence_depth=4,
+                                      time_limit=0.0, use_ema=args.ema),
+        ))
+    for s in args.mcts_sims:
+        configs.append((
+            f"mcts sims={s} batch={args.sim_batch}",
+            lambda s=s: Pos2MoveV2MctsBot(model_dir=args.model_dir, num_simulations=s,
+                                          sim_batch=args.sim_batch, time_limit=0.0, use_ema=args.ema),
+        ))
+
+    summary = []
+    for label, factory in configs:
+        print(f"\n{'#' * 64}\n# CONFIG: {label}\n{'#' * 64}")
+        try:
+            bot = factory()
+            t0 = time.time()
+            results = run_gauntlet(
+                bot=bot, stockfish_path=args.sf_path, skill_levels=args.skills,
+                games_per_level=args.games, sf_time_limit=args.sf_time, pgn_path=None,
+            )
+            elo = weighted_elo(results)
+            secs = time.time() - t0
+            summary.append((label, elo, results, secs))
+            del bot
+        except Exception as e:  # pragma: no cover
+            print(f"CONFIG FAILED: {e}")
+            summary.append((label, None, [], 0.0))
+
+    print(f"\n{'=' * 64}\nTUNING SUMMARY (model: {args.model_dir})\n{'=' * 64}")
+    print(f"{'config':<28}{'est Elo':>9}{'levels':>9}{'time':>9}")
+    print("-" * 64)
+    for label, elo, results, secs in sorted(summary, key=lambda x: (x[1] or -1), reverse=True):
+        elo_s = f"~{round(elo / 25) * 25}" if elo is not None else "N/A"
+        print(f"{label:<28}{elo_s:>9}{len(results):>9}{secs:>8.0f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tune_vs_stockfish.py
+++ b/scripts/tune_vs_stockfish.py
@@ -43,6 +43,30 @@ def weighted_elo(results: list[dict]) -> float | None:
     return sum(e * w for e, w in zip(ests, ws)) / sum(ws)
 
 
+def mle_elo(results: list[dict]) -> float | None:
+    """Single maximum-likelihood Elo over ALL games (logistic model).
+
+    Unlike averaging per-level estimates, saturated easy levels (100%/0%)
+    contribute ~no gradient instead of biasing the mean toward their capped
+    value, so this doesn't get dragged down by low-skill sweeps.
+    """
+    import numpy as np
+
+    e = np.array([r["ref_elo"] for r in results], float)
+    g = np.array([r["wins"] + r["draws"] + r["losses"] for r in results], float)
+    s = np.array([r["score"] for r in results], float)
+    if g.sum() == 0:
+        return None
+    wins, losses = s * g, g - s * g
+    best_R, best_ll = None, -1e18
+    for R in np.arange(800, 3000, 1.0):
+        p = np.clip(1 / (1 + 10 ** ((e - R) / 400)), 1e-9, 1 - 1e-9)
+        ll = (wins * np.log(p) + losses * np.log(1 - p)).sum()
+        if ll > best_ll:
+            best_ll, best_R = ll, R
+    return best_R
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("model_dir", help="Model dir (e.g. run21 best_model)")
@@ -53,6 +77,9 @@ def main():
     p.add_argument("--ab-depths", type=int, nargs="*", default=[2, 3, 4])
     p.add_argument("--mcts-sims", type=int, nargs="*", default=[200, 400, 800])
     p.add_argument("--sim-batch", type=int, default=16)
+    p.add_argument("--c-puct", type=float, default=1.5)
+    p.add_argument("--prior-temp", type=float, default=1.0)
+    p.add_argument("--fpu", type=float, default=None)
     p.add_argument("--ema", action="store_true")
     args = p.parse_args()
 
@@ -66,9 +93,11 @@ def main():
         ))
     for s in args.mcts_sims:
         configs.append((
-            f"mcts sims={s} batch={args.sim_batch}",
+            f"mcts sims={s} cpuct={args.c_puct} fpu={args.fpu}",
             lambda s=s: Pos2MoveV2MctsBot(model_dir=args.model_dir, num_simulations=s,
-                                          sim_batch=args.sim_batch, time_limit=0.0, use_ema=args.ema),
+                                          sim_batch=args.sim_batch, c_puct=args.c_puct,
+                                          prior_temp=args.prior_temp, fpu=args.fpu,
+                                          time_limit=0.0, use_ema=args.ema),
         ))
 
     summary = []
@@ -81,20 +110,21 @@ def main():
                 bot=bot, stockfish_path=args.sf_path, skill_levels=args.skills,
                 games_per_level=args.games, sf_time_limit=args.sf_time, pgn_path=None,
             )
-            elo = weighted_elo(results)
+            elo = mle_elo(results)  # principled single-Elo MLE (not biased by easy levels)
             secs = time.time() - t0
-            summary.append((label, elo, results, secs))
+            summary.append((label, elo, weighted_elo(results), results, secs))
             del bot
         except Exception as e:  # pragma: no cover
             print(f"CONFIG FAILED: {e}")
-            summary.append((label, None, [], 0.0))
+            summary.append((label, None, None, [], 0.0))
 
     print(f"\n{'=' * 64}\nTUNING SUMMARY (model: {args.model_dir})\n{'=' * 64}")
-    print(f"{'config':<28}{'est Elo':>9}{'levels':>9}{'time':>9}")
+    print(f"{'config':<28}{'MLE Elo':>9}{'(wtd)':>8}{'levels':>8}{'time':>9}")
     print("-" * 64)
-    for label, elo, results, secs in sorted(summary, key=lambda x: (x[1] or -1), reverse=True):
+    for label, elo, wtd, results, secs in sorted(summary, key=lambda x: (x[1] or -1), reverse=True):
         elo_s = f"~{round(elo / 25) * 25}" if elo is not None else "N/A"
-        print(f"{label:<28}{elo_s:>9}{len(results):>9}{secs:>8.0f}s")
+        wtd_s = f"{round(wtd):.0f}" if wtd is not None else "N/A"
+        print(f"{label:<28}{elo_s:>9}{wtd_s:>8}{len(results):>8}{secs:>9.0f}s")
 
 
 if __name__ == "__main__":

--- a/src/chesstransformer/bots/__init__.py
+++ b/src/chesstransformer/bots/__init__.py
@@ -1,4 +1,5 @@
 from .pos2move_v2_bot import Pos2MoveV2Bot
+from .pos2move_v2_mcts_bot import Pos2MoveV2MctsBot
 from .random_bot import RandomBot
 
-__all__ = ["Pos2MoveV2Bot", "RandomBot"]
+__all__ = ["Pos2MoveV2Bot", "Pos2MoveV2MctsBot", "RandomBot"]

--- a/src/chesstransformer/bots/pos2move_v2_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_bot.py
@@ -7,6 +7,7 @@ import time as _time
 from pathlib import Path
 
 import chess
+import chess.polyglot
 import numpy as np
 import torch
 from safetensors import safe_open
@@ -15,7 +16,11 @@ from chesstransformer.models.tokenizer import PostionTokenizer
 from chesstransformer.models.tokenizer.alphazero_move_encoder import move_to_action_plane
 from chesstransformer.models.transformer.pos2move_v2 import Pos2MoveV2
 
-_DEFAULT_RUN = Path(__file__).parents[3] / "data" / "models" / "pos2move_v2"
+_DEFAULT_RUN = Path(__file__).parents[3] / "data" / "models" / "pos2move_v2.1"
+
+# Fixed batch-size buckets. Batched evals are zero-padded up to the next bucket
+# so the (optionally compiled) model only ever sees a handful of static shapes.
+_BATCH_BUCKETS = (4, 8, 16, 32)
 
 
 class _SearchTimeout(Exception):
@@ -32,10 +37,13 @@ class Pos2MoveV2Bot:
         tt_size: int = 500_000,
         device: str = "cuda" if torch.cuda.is_available() else "cpu",
         use_ema: bool = False,
+        compile: bool = True,
+        quiescence_depth: int = 4,
     ):
         self.depth = depth
         self.top_p = top_p
         self.time_limit = time_limit
+        self.quiescence_depth = quiescence_depth
         self.nodes_searched = 0
         self.tt_hits = 0
         self.completed_depth = 0
@@ -84,10 +92,24 @@ class Pos2MoveV2Bot:
         self._buf_player = torch.zeros(1, dtype=torch.long, device=device)
         self._buf_castling = torch.zeros(1, dtype=torch.long, device=device)
         self._buf_ep = torch.zeros(1, dtype=torch.long, device=device)
+        self._batch_bufs: dict[int, tuple] = {}
 
         self._tt_size = tt_size
-        self._tt: dict[str, tuple[np.ndarray, float]] = {}
+        self._tt: dict[int, tuple[np.ndarray, float]] = {}
         self._deadline: float = 0.0
+
+        # CUDA graphs collapse the Python/kernel-launch overhead that dominates
+        # this tiny model at small batch sizes. Bucketed batches keep the number
+        # of captured graphs small. Falls back to eager if compilation fails.
+        self._compiled = False
+        if compile and device == "cuda":
+            self._eager_model = self.model
+            try:
+                self.model = torch.compile(self.model, mode="reduce-overhead")
+                self._compiled = True
+            except Exception as e:  # pragma: no cover - environment dependent
+                print(f"WARNING: torch.compile unavailable ({e}); using eager.")
+                self.model = self._eager_model
 
         self._warmup()
 
@@ -98,8 +120,24 @@ class Pos2MoveV2Bot:
 
     @torch.no_grad()
     def _warmup(self):
-        for _ in range(3):
-            self.model(self._buf_board, self._buf_player, self._buf_castling, self._buf_ep)
+        try:
+            # Batch-1 path (single-position _evaluate).
+            for _ in range(3):
+                self.model(self._buf_board, self._buf_player, self._buf_castling, self._buf_ep)
+            # Each bucket shape used by _batch_run, so compilation / CUDA-graph
+            # capture happens up front rather than mid-search.
+            for bucket in _BATCH_BUCKETS:
+                b, p, c, e = self._batch_buffers(bucket)
+                for _ in range(3):
+                    self.model(b, p, c, e)
+        except Exception as e:  # pragma: no cover - environment dependent
+            if self._compiled:
+                print(f"WARNING: compiled warmup failed ({e}); falling back to eager.")
+                self.model = self._eager_model
+                self._compiled = False
+                self.model(self._buf_board, self._buf_player, self._buf_castling, self._buf_ep)
+            else:
+                raise
         if self.device == "cuda":
             torch.cuda.synchronize()
 
@@ -156,9 +194,8 @@ class Pos2MoveV2Bot:
 
     @torch.no_grad()
     def _evaluate(self, board: chess.Board) -> tuple[np.ndarray, float]:
-        ep = chess.square_name(board.ep_square) if board.ep_square else "-"
-        fen = f"{board.board_fen()} {'w' if board.turn else 'b'} {board.castling_xfen() or '-'} {ep}"
-        cached = self._tt.get(fen)
+        key = chess.polyglot.zobrist_hash(board)
+        cached = self._tt.get(key)
         if cached is not None:
             self.tt_hits += 1
             return cached
@@ -190,17 +227,44 @@ class Pos2MoveV2Bot:
 
         if self._tt_size > 0 and len(self._tt) >= self._tt_size:
             del self._tt[next(iter(self._tt))]
-        self._tt[fen] = (logits, value)
+        self._tt[key] = (logits, value)
 
         return logits, value
 
+    def _batch_buffers(self, bucket: int):
+        """Persistent zero-padded device buffers per bucket size.
+
+        Using a small fixed set of batch shapes keeps torch.compile / CUDA
+        graphs from recompiling (and re-capturing) on every distinct batch size.
+        """
+        bufs = self._batch_bufs.get(bucket)
+        if bufs is None:
+            bufs = (
+                torch.zeros(bucket, 64, dtype=torch.long, device=self.device),
+                torch.zeros(bucket, dtype=torch.long, device=self.device),
+                torch.zeros(bucket, dtype=torch.long, device=self.device),
+                torch.zeros(bucket, dtype=torch.long, device=self.device),
+            )
+            self._batch_bufs[bucket] = bufs
+        return bufs
+
+    @staticmethod
+    def _bucket_for(n: int) -> int:
+        for b in _BATCH_BUCKETS:
+            if n <= b:
+                return b
+        return _BATCH_BUCKETS[-1]
+
     @torch.no_grad()
-    def _batch_run(self, items: list[tuple[np.ndarray, int, int, int, str]]):
+    def _batch_run(self, items: list[tuple[np.ndarray, int, int, int, int]]):
         n = len(items)
-        board_arr = torch.zeros(n, 64, dtype=torch.long, device=self.device)
-        player_arr = torch.zeros(n, dtype=torch.long, device=self.device)
-        castling_arr = torch.zeros(n, dtype=torch.long, device=self.device)
-        ep_arr = torch.zeros(n, dtype=torch.long, device=self.device)
+        bucket = self._bucket_for(n)
+        board_arr, player_arr, castling_arr, ep_arr = self._batch_buffers(bucket)
+        # Zero the padding rows (token/index 0 is a valid embedding index).
+        board_arr.zero_()
+        player_arr.zero_()
+        castling_arr.zero_()
+        ep_arr.zero_()
 
         for i, (pos, player, castling, ep, _) in enumerate(items):
             board_arr[i] = torch.tensor(pos, dtype=torch.long)
@@ -209,13 +273,14 @@ class Pos2MoveV2Bot:
             ep_arr[i] = ep
 
         move_logits, value_t = self.model(board_arr, player_arr, castling_arr, ep_arr)
-        logits_np = move_logits.float().cpu().numpy()
-        values_np = value_t.float().cpu().numpy()
+        # Slice off padding before the host copy.
+        logits_np = move_logits[:n].float().cpu().numpy()
+        values_np = value_t[:n].float().cpu().numpy()
 
-        for i, (_, _, _, _, fen) in enumerate(items):
+        for i, (_, _, _, _, key) in enumerate(items):
             if self._tt_size > 0 and len(self._tt) >= self._tt_size:
                 del self._tt[next(iter(self._tt))]
-            self._tt[fen] = (logits_np[i], float(values_np[i].item()))
+            self._tt[key] = (logits_np[i], float(values_np[i].item()))
 
     def _encode_position(self, board: chess.Board) -> tuple[np.ndarray, int, int, int]:
         position = self.position_tokenizer.encode(board)
@@ -236,11 +301,15 @@ class Pos2MoveV2Bot:
         uncached = []
         for move in moves:
             board.push(move)
-            ep = chess.square_name(board.ep_square) if board.ep_square else "-"
-            fen = f"{board.board_fen()} {'w' if board.turn else 'b'} {board.castling_xfen() or '-'} {ep}"
-            if fen not in self._tt and not board.is_game_over(claim_draw=True):
+            key = chess.polyglot.zobrist_hash(board)
+            # Cheap terminal proxy: positions with no legal moves (checkmate /
+            # stalemate) are scored directly by _alpha_beta, so skip a wasted
+            # model eval on them. Claimable-draw positions (threefold / 50-move)
+            # still have legal moves; caching their eval is harmless because
+            # _alpha_beta's authoritative is_game_over check overrides it.
+            if key not in self._tt and any(board.legal_moves):
                 pos, player, castling, ep_file = self._encode_position(board)
-                uncached.append((pos, player, castling, ep_file, fen))
+                uncached.append((pos, player, castling, ep_file, key))
             board.pop()
         if len(uncached) >= 2:
             self._batch_run(uncached)
@@ -271,15 +340,78 @@ class Pos2MoveV2Bot:
                 best_move = move
         return best_move, alpha
 
+    def _terminal_value(self, board: chess.Board) -> float | None:
+        """Negamax terminal value (side-to-move POV), or None if not terminal.
+
+        Uses cheap checks instead of ``is_game_over(claim_draw=True)`` (whose
+        ``can_claim_threefold_repetition`` dominated the profile): no-legal-move
+        positions are mate/stalemate, and draws are detected via material,
+        3-fold repetition and the 50-move clock — without the expensive
+        "a move *could* force a repetition" probe.
+        """
+        if not any(board.legal_moves):
+            return -1.0 if board.is_check() else 0.0
+        if (
+            board.is_insufficient_material()
+            or board.is_repetition(3)
+            or board.halfmove_clock >= 100
+        ):
+            return 0.0
+        return None
+
+    @torch.no_grad()
+    def _quiescence(self, board: chess.Board, alpha: float, beta: float, qdepth: int) -> float:
+        """Resolve tactical noise before trusting the value head.
+
+        Stand-pat on the value head, then search only forcing moves (captures
+        and promotions) so the leaf isn't evaluated in the middle of an
+        unresolved exchange (the horizon effect).
+        """
+        self.nodes_searched += 1
+        self._check_time()
+
+        term = self._terminal_value(board)
+        if term is not None:
+            return term
+
+        logits, stand_pat = self._evaluate(board)
+        if stand_pat >= beta:
+            return beta
+        if stand_pat > alpha:
+            alpha = stand_pat
+        if qdepth <= 0:
+            return alpha
+
+        noisy = []
+        for move in board.legal_moves:
+            if board.is_capture(move) or move.promotion:
+                plane = move_to_action_plane(move.from_square, move.to_square, move.promotion)
+                noisy.append((float(logits[move.from_square, plane]), move))
+        if not noisy:
+            return alpha
+        noisy.sort(key=lambda x: -x[0])
+
+        for _, move in noisy:
+            board.push(move)
+            score = -self._quiescence(board, -beta, -alpha, qdepth - 1)
+            board.pop()
+            if score >= beta:
+                return beta
+            if score > alpha:
+                alpha = score
+        return alpha
+
     def _alpha_beta(self, board: chess.Board, depth: int, alpha: float, beta: float, max_depth: int) -> float:
         self.nodes_searched += 1
         self._check_time()
 
-        if board.is_game_over(claim_draw=True):
-            result = board.result(claim_draw=True)
-            return 0.0 if result == "1/2-1/2" else -1.0
+        term = self._terminal_value(board)
+        if term is not None:
+            return term
 
         if depth <= 0:
+            if self.quiescence_depth > 0:
+                return self._quiescence(board, alpha, beta, self.quiescence_depth)
             _, value = self._evaluate(board)
             return value
 

--- a/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
@@ -48,11 +48,20 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         prior_temp: float = 1.0,
         fpu: float | None = 0.2,
         sim_batch: int = 16,
+        tree_reuse: bool = True,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.num_simulations = num_simulations
         self.c_puct = c_puct
+        # Tree reuse: keep the searched subtree under the moves actually played
+        # and re-root it next move, so prior visits carry over (effectively
+        # deeper search for free). Requires the caller to keep board.move_stack
+        # across calls; falls back to a fresh tree otherwise (e.g. boards rebuilt
+        # from FEN with no history).
+        self.tree_reuse = tree_reuse
+        self._reuse_root: _Node | None = None
+        self._reuse_moves: list | None = None
         # prior_temp > 1 flattens the policy priors so good-but-low-prior moves
         # still get explored (the value head can then promote them). fpu (first-
         # play-urgency): value unvisited children as parent_Q - fpu; None keeps
@@ -205,18 +214,43 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
                 self._expand_from_logits(node, moves, logits)
             self._backup_vl(path, value)
 
+    def _take_reuse_root(self, board: chess.Board) -> _Node | None:
+        """Re-root the retained tree to ``board`` if it follows the previous
+        search position by a few plies (the moves actually played). Consumes the
+        stored tree; returns an expanded node to use as root, or None for fresh.
+        """
+        root = self._reuse_root
+        self._reuse_root = None
+        if root is None or self._reuse_moves is None:
+            return None
+        ms = board.move_stack
+        rp = len(self._reuse_moves)
+        gap = len(ms) - rp
+        # Normal case: our move + opponent reply (gap 2). Allow 1-4 for safety;
+        # require an exact history-prefix match so we never reuse another game.
+        if gap < 1 or gap > 4 or list(ms[:rp]) != self._reuse_moves:
+            return None
+        node = root
+        for mv in ms[rp:]:
+            if not (node.expanded and mv in node.children):
+                return None
+            node = node.children[mv]
+        return node if node.expanded else None
+
     def predict(self, board: chess.Board) -> tuple[str, float | None]:
         self.nodes_searched = 0
         self.tt_hits = 0
         self.completed_depth = self.num_simulations
 
-        root = _Node(prior=1.0)
-        root_value = self._expand(root, board)
-        if not root.children:
-            return next(iter(board.legal_moves)).uci(), 0.0
-        # Seed the root with one visit so the first PUCT term is well-defined.
-        root.N = 1
-        root.W = root_value
+        root = self._take_reuse_root(board) if self.tree_reuse else None
+        if root is None:
+            root = _Node(prior=1.0)
+            root_value = self._expand(root, board)
+            if not root.children:
+                return next(iter(board.legal_moves)).uci(), 0.0
+            # Seed the root with one visit so the first PUCT term is well-defined.
+            root.N = 1
+            root.W = root_value
 
         if self.sim_batch <= 1:
             for _ in range(self.num_simulations):
@@ -231,6 +265,12 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         best_move, best_child = max(root.children.items(), key=lambda kv: kv[1].N)
         # Root value from side-to-move POV (negate child's POV).
         best_value = -best_child.Q
+
+        # Retain the tree (and the history it was searched at) for next move.
+        if self.tree_reuse:
+            self._reuse_root = root
+            self._reuse_moves = list(board.move_stack)
+
         return best_move.uci(), best_value
 
 

--- a/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
@@ -44,23 +44,29 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         self,
         *args,
         num_simulations: int = 400,
-        c_puct: float = 1.5,
+        c_puct: float = 1.0,
+        prior_temp: float = 1.0,
+        fpu: float | None = 0.2,
         sim_batch: int = 16,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.num_simulations = num_simulations
         self.c_puct = c_puct
+        # prior_temp > 1 flattens the policy priors so good-but-low-prior moves
+        # still get explored (the value head can then promote them). fpu (first-
+        # play-urgency): value unvisited children as parent_Q - fpu; None keeps
+        # the legacy behavior (unvisited contribute 0 to selection).
+        self.prior_temp = prior_temp
+        self.fpu = fpu
         # Leaves collected per network call. >1 amortizes the GPU->CPU sync that
         # otherwise dominates (one stall per simulation). 1 = legacy single-leaf.
         # Capped at the largest batch bucket so _batch_run's preallocated buffers
         # (and the captured CUDA graphs) are never overrun.
         self.sim_batch = max(1, min(sim_batch, _BATCH_BUCKETS[-1]))
 
-    def _priors_and_value(self, board: chess.Board):
-        """Legal moves, their softmax policy priors, and the value-head score."""
-        logits, value = self._evaluate(board)
-        moves = list(board.legal_moves)
+    def _compute_priors(self, moves: list[chess.Move], logits: np.ndarray) -> np.ndarray:
+        """Softmax policy priors over legal moves, with temperature flattening."""
         scores = np.array(
             [
                 logits[m.from_square, move_to_action_plane(m.from_square, m.to_square, m.promotion)]
@@ -68,10 +74,16 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
             ],
             dtype=np.float64,
         )
+        scores /= self.prior_temp
         scores -= scores.max()
         exp = np.exp(scores)
-        probs = exp / exp.sum()
-        return moves, probs, value
+        return exp / exp.sum()
+
+    def _priors_and_value(self, board: chess.Board):
+        """Legal moves, their softmax policy priors, and the value-head score."""
+        logits, value = self._evaluate(board)
+        moves = list(board.legal_moves)
+        return moves, self._compute_priors(moves, logits), value
 
     def _expand(self, node: _Node, board: chess.Board) -> float:
         self.nodes_searched += 1
@@ -79,22 +91,9 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         node.children = {m: _Node(float(p)) for m, p in zip(moves, probs)}
         return value
 
-    @staticmethod
-    def _softmax_priors(moves: list[chess.Move], logits: np.ndarray) -> np.ndarray:
-        scores = np.array(
-            [
-                logits[m.from_square, move_to_action_plane(m.from_square, m.to_square, m.promotion)]
-                for m in moves
-            ],
-            dtype=np.float64,
-        )
-        scores -= scores.max()
-        exp = np.exp(scores)
-        return exp / exp.sum()
-
     def _expand_from_logits(self, node: _Node, moves: list[chess.Move], logits: np.ndarray):
         self.nodes_searched += 1
-        probs = self._softmax_priors(moves, logits)
+        probs = self._compute_priors(moves, logits)
         node.children = {m: _Node(float(p)) for m, p in zip(moves, probs)}
 
     @staticmethod
@@ -114,14 +113,17 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
 
     def _select_child(self, node: _Node) -> tuple[chess.Move, _Node]:
         sqrt_total = math.sqrt(node.N)
+        # FPU: value unvisited children relative to the parent's own estimate.
+        fpu_q = (node.Q - self.fpu) if self.fpu is not None else 0.0
         best_score = -float("inf")
         best_move = None
         best_child = None
         for move, child in node.children.items():
             # child.Q is from the child's side-to-move POV; negate for the
-            # parent's POV (negamax). Unvisited children get Q=0.
+            # parent's POV (negamax).
             u = self.c_puct * child.prior * sqrt_total / (1 + child.N)
-            score = -child.Q + u
+            q = fpu_q if child.N == 0 else -child.Q
+            score = q + u
             if score > best_score:
                 best_score = score
                 best_move = move

--- a/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
@@ -43,7 +43,7 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
     def __init__(
         self,
         *args,
-        num_simulations: int = 400,
+        num_simulations: int = 800,
         c_puct: float = 1.0,
         prior_temp: float = 1.0,
         fpu: float | None = 0.2,
@@ -240,7 +240,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("model_dir", nargs="?", default=str(_DEFAULT_RUN))
-    parser.add_argument("--sims", type=int, default=400)
+    parser.add_argument("--sims", type=int, default=800)
     parser.add_argument("--c-puct", type=float, default=1.5)
     parser.add_argument("--ema", action="store_true")
     args = parser.parse_args()

--- a/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
@@ -1,0 +1,258 @@
+"""AlphaZero-style PUCT MCTS engine for Pos2MoveV2.
+
+Subclasses :class:`Pos2MoveV2Bot` to reuse its (optionally torch.compiled and
+cached) ``_evaluate`` — the policy head supplies move priors and the value head
+scores leaves. Move selection is by visit count, the standard AlphaZero choice.
+
+This is a correctness-first single-leaf implementation: one network evaluation
+per simulation (the compiled batch-1 path is fast). Collecting several leaves
+per network call with virtual loss — to better fill the GPU — is a natural
+follow-up that this structure leaves room for.
+"""
+
+from __future__ import annotations
+
+import math
+
+import chess
+import numpy as np
+
+from chesstransformer.bots.pos2move_v2_bot import _BATCH_BUCKETS, _DEFAULT_RUN, Pos2MoveV2Bot
+from chesstransformer.models.tokenizer.alphazero_move_encoder import move_to_action_plane
+
+
+class _Node:
+    __slots__ = ("prior", "N", "W", "children")
+
+    def __init__(self, prior: float):
+        self.prior = prior
+        self.N = 0          # visit count
+        self.W = 0.0        # total value, from this node's side-to-move POV
+        self.children: dict[chess.Move, _Node] | None = None
+
+    @property
+    def Q(self) -> float:
+        return self.W / self.N if self.N else 0.0
+
+    @property
+    def expanded(self) -> bool:
+        return self.children is not None
+
+
+class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
+    def __init__(
+        self,
+        *args,
+        num_simulations: int = 400,
+        c_puct: float = 1.5,
+        sim_batch: int = 16,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.num_simulations = num_simulations
+        self.c_puct = c_puct
+        # Leaves collected per network call. >1 amortizes the GPU->CPU sync that
+        # otherwise dominates (one stall per simulation). 1 = legacy single-leaf.
+        # Capped at the largest batch bucket so _batch_run's preallocated buffers
+        # (and the captured CUDA graphs) are never overrun.
+        self.sim_batch = max(1, min(sim_batch, _BATCH_BUCKETS[-1]))
+
+    def _priors_and_value(self, board: chess.Board):
+        """Legal moves, their softmax policy priors, and the value-head score."""
+        logits, value = self._evaluate(board)
+        moves = list(board.legal_moves)
+        scores = np.array(
+            [
+                logits[m.from_square, move_to_action_plane(m.from_square, m.to_square, m.promotion)]
+                for m in moves
+            ],
+            dtype=np.float64,
+        )
+        scores -= scores.max()
+        exp = np.exp(scores)
+        probs = exp / exp.sum()
+        return moves, probs, value
+
+    def _expand(self, node: _Node, board: chess.Board) -> float:
+        self.nodes_searched += 1
+        moves, probs, value = self._priors_and_value(board)
+        node.children = {m: _Node(float(p)) for m, p in zip(moves, probs)}
+        return value
+
+    @staticmethod
+    def _softmax_priors(moves: list[chess.Move], logits: np.ndarray) -> np.ndarray:
+        scores = np.array(
+            [
+                logits[m.from_square, move_to_action_plane(m.from_square, m.to_square, m.promotion)]
+                for m in moves
+            ],
+            dtype=np.float64,
+        )
+        scores -= scores.max()
+        exp = np.exp(scores)
+        return exp / exp.sum()
+
+    def _expand_from_logits(self, node: _Node, moves: list[chess.Move], logits: np.ndarray):
+        self.nodes_searched += 1
+        probs = self._softmax_priors(moves, logits)
+        node.children = {m: _Node(float(p)) for m, p in zip(moves, probs)}
+
+    @staticmethod
+    def _backup_vl(path: list[_Node], leaf_value: float):
+        """Back up a leaf value, undoing the virtual loss applied during descent.
+
+        Descent did ``N += 1; W += 1`` on each path node (a virtual *win* in the
+        node's own POV, which looks like a loss to its parent under the negamax
+        ``-child.Q`` selection, so concurrent descents avoid the path). Here we
+        subtract that +1 back out and apply the real, sign-alternating value. N
+        is left as-is since the virtual-loss pass already counted the visit.
+        """
+        v = leaf_value
+        for node in reversed(path):
+            node.W += v - 1.0
+            v = -v
+
+    def _select_child(self, node: _Node) -> tuple[chess.Move, _Node]:
+        sqrt_total = math.sqrt(node.N)
+        best_score = -float("inf")
+        best_move = None
+        best_child = None
+        for move, child in node.children.items():
+            # child.Q is from the child's side-to-move POV; negate for the
+            # parent's POV (negamax). Unvisited children get Q=0.
+            u = self.c_puct * child.prior * sqrt_total / (1 + child.N)
+            score = -child.Q + u
+            if score > best_score:
+                best_score = score
+                best_move = move
+                best_child = child
+        return best_move, best_child
+
+    def _simulate(self, root: _Node, board: chess.Board):
+        node = root
+        path = [node]
+        pushed = 0
+        while node.expanded:
+            move, child = self._select_child(node)
+            board.push(move)
+            pushed += 1
+            node = child
+            path.append(node)
+
+        term = self._terminal_value(board)
+        value = term if term is not None else self._expand(node, board)
+
+        # Negamax backup: value is from the leaf's side-to-move POV; flip sign
+        # at each step toward the root.
+        v = value
+        for n in reversed(path):
+            n.N += 1
+            n.W += v
+            v = -v
+
+        for _ in range(pushed):
+            board.pop()
+
+    def _run_batch(self, root: _Node, board: chess.Board, batch_n: int):
+        """Collect up to ``batch_n`` leaves (virtual loss applied during descent),
+        evaluate the unique non-terminal ones in a single batched forward, then
+        expand and back them up. This turns ~batch_n synchronous GPU->CPU syncs
+        into one."""
+        leaves = []          # (path, node, key, moves) awaiting network eval
+        items_by_key = {}    # key -> (pos, player, castling, ep, key) for _batch_run
+
+        for _ in range(batch_n):
+            node = root
+            path = [node]
+            pushed = 0
+            while node.expanded:
+                move, child = self._select_child(node)
+                board.push(move)
+                pushed += 1
+                node = child
+                path.append(node)
+
+            # Virtual loss: a virtual *win* in each node's own POV (looks like a
+            # loss to its parent under negamax -child.Q selection) so other
+            # descents in this batch avoid re-exploring the same path.
+            for n in path:
+                n.N += 1
+                n.W += 1.0
+
+            term = self._terminal_value(board)
+            if term is not None:
+                self._backup_vl(path, term)
+            else:
+                key = chess.polyglot.zobrist_hash(board)
+                moves = list(board.legal_moves)
+                leaves.append((path, node, key, moves))
+                if key not in items_by_key:
+                    pos, player, castling, ep = self._encode_position(board)
+                    items_by_key[key] = (pos, player, castling, ep, key)
+
+            for _ in range(pushed):
+                board.pop()
+
+        # One batched forward (+ one sync) populates the TT for every position.
+        if items_by_key:
+            self._batch_run(list(items_by_key.values()))
+
+        for path, node, key, moves in leaves:
+            logits, value = self._tt[key]
+            if not node.expanded:
+                self._expand_from_logits(node, moves, logits)
+            self._backup_vl(path, value)
+
+    def predict(self, board: chess.Board) -> tuple[str, float | None]:
+        self.nodes_searched = 0
+        self.tt_hits = 0
+        self.completed_depth = self.num_simulations
+
+        root = _Node(prior=1.0)
+        root_value = self._expand(root, board)
+        if not root.children:
+            return next(iter(board.legal_moves)).uci(), 0.0
+        # Seed the root with one visit so the first PUCT term is well-defined.
+        root.N = 1
+        root.W = root_value
+
+        if self.sim_batch <= 1:
+            for _ in range(self.num_simulations):
+                self._simulate(root, board)
+        else:
+            done = 0
+            while done < self.num_simulations:
+                n = min(self.sim_batch, self.num_simulations - done)
+                self._run_batch(root, board, n)
+                done += n
+
+        best_move, best_child = max(root.children.items(), key=lambda kv: kv[1].N)
+        # Root value from side-to-move POV (negate child's POV).
+        best_value = -best_child.Q
+        return best_move.uci(), best_value
+
+
+if __name__ == "__main__":
+    import argparse
+    import time
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_dir", nargs="?", default=str(_DEFAULT_RUN))
+    parser.add_argument("--sims", type=int, default=400)
+    parser.add_argument("--c-puct", type=float, default=1.5)
+    parser.add_argument("--ema", action="store_true")
+    args = parser.parse_args()
+
+    bot = Pos2MoveV2MctsBot(
+        model_dir=args.model_dir, num_simulations=args.sims, c_puct=args.c_puct,
+        time_limit=0.0, use_ema=args.ema,
+    )
+    board = chess.Board()
+    for _ in range(8):
+        t0 = time.time()
+        mv, val = bot.predict(board)
+        print(f"{'W' if board.turn else 'B'} {mv} val={val:+.3f} "
+              f"sims={bot.num_simulations} nodes={bot.nodes_searched} time={time.time()-t0:.2f}s")
+        board.push_uci(mv)
+        if board.is_game_over():
+            break

--- a/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
@@ -1,13 +1,15 @@
 """AlphaZero-style PUCT MCTS engine for Pos2MoveV2.
 
-Subclasses :class:`Pos2MoveV2Bot` to reuse its (optionally torch.compiled and
+Subclasses :class:`Pos2MoveV2Bot` to reuse its (torch.compiled, transposition-
 cached) ``_evaluate`` — the policy head supplies move priors and the value head
-scores leaves. Move selection is by visit count, the standard AlphaZero choice.
+scores leaves. Move selection is by visit count (the standard AlphaZero choice).
 
-This is a correctness-first single-leaf implementation: one network evaluation
-per simulation (the compiled batch-1 path is fast). Collecting several leaves
-per network call with virtual loss — to better fill the GPU — is a natural
-follow-up that this structure leaves room for.
+Node representation is **edge-centric**: a node stores its children's visit
+counts / values / priors as numpy arrays, and child ``_Node`` objects are created
+lazily only when a child is actually descended into. This avoids allocating a
+node per legal move at every expansion (which dominated latency) and lets PUCT
+selection run vectorized over the arrays. Leaves are collected in batches with
+virtual loss so the network sees one batched forward per wave.
 """
 
 from __future__ import annotations
@@ -22,21 +24,22 @@ from chesstransformer.models.tokenizer.alphazero_move_encoder import move_to_act
 
 
 class _Node:
-    __slots__ = ("prior", "N", "W", "children")
+    """A search node. Child visit stats live in arrays here (edge-centric); child
+    ``_Node`` objects are created lazily on first descent. A node is *expanded*
+    once ``moves`` is set."""
 
-    def __init__(self, prior: float):
-        self.prior = prior
-        self.N = 0          # visit count
-        self.W = 0.0        # total value, from this node's side-to-move POV
-        self.children: dict[chess.Move, _Node] | None = None
+    __slots__ = ("moves", "priors", "child_N", "child_W", "children")
 
-    @property
-    def Q(self) -> float:
-        return self.W / self.N if self.N else 0.0
+    def __init__(self):
+        self.moves: list[chess.Move] | None = None
+        self.priors: np.ndarray | None = None
+        self.child_N: np.ndarray | None = None  # int64, per child
+        self.child_W: np.ndarray | None = None  # float64, child-POV total value
+        self.children: list[_Node | None] | None = None
 
     @property
     def expanded(self) -> bool:
-        return self.children is not None
+        return self.moves is not None
 
 
 class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
@@ -74,6 +77,7 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         # (and the captured CUDA graphs) are never overrun.
         self.sim_batch = max(1, min(sim_batch, _BATCH_BUCKETS[-1]))
 
+    # ── expansion ────────────────────────────────────────────────────────
     def _compute_priors(self, moves: list[chess.Move], logits: np.ndarray) -> np.ndarray:
         """Softmax policy priors over legal moves, with temperature flattening."""
         scores = np.array(
@@ -88,108 +92,95 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         exp = np.exp(scores)
         return exp / exp.sum()
 
-    def _priors_and_value(self, board: chess.Board):
-        """Legal moves, their softmax policy priors, and the value-head score."""
+    def _expand_node(self, node: _Node, moves: list[chess.Move], priors: np.ndarray):
+        self.nodes_searched += 1
+        n = len(moves)
+        node.moves = moves
+        node.priors = priors
+        node.child_N = np.zeros(n, dtype=np.int64)
+        node.child_W = np.zeros(n, dtype=np.float64)
+        node.children = [None] * n
+
+    def _expand_leaf(self, node: _Node, board: chess.Board) -> float:
+        """Evaluate ``board`` (policy + value) and expand ``node``; return value."""
         logits, value = self._evaluate(board)
         moves = list(board.legal_moves)
-        return moves, self._compute_priors(moves, logits), value
-
-    def _expand(self, node: _Node, board: chess.Board) -> float:
-        self.nodes_searched += 1
-        moves, probs, value = self._priors_and_value(board)
-        node.children = {m: _Node(float(p)) for m, p in zip(moves, probs)}
+        self._expand_node(node, moves, self._compute_priors(moves, logits))
         return value
 
-    def _expand_from_logits(self, node: _Node, moves: list[chess.Move], logits: np.ndarray):
-        self.nodes_searched += 1
-        probs = self._compute_priors(moves, logits)
-        node.children = {m: _Node(float(p)) for m, p in zip(moves, probs)}
+    # ── selection / descent / backup ─────────────────────────────────────
+    def _select_idx(self, node: _Node) -> int:
+        """Vectorized PUCT: pick the child index maximizing -Q + U."""
+        N = node.child_N
+        total = int(N.sum())
+        sqrt_total = math.sqrt(1.0 + total)  # +1 ≈ the node's own eval visit
+        # value-to-parent = -child_Q (child stores value from its own POV).
+        q_parent = np.zeros_like(node.child_W)
+        np.divide(-node.child_W, N, out=q_parent, where=N > 0)
+        if self.fpu is not None:
+            parent_q = (-node.child_W.sum() / total) if total > 0 else 0.0
+            q_parent[N == 0] = parent_q - self.fpu
+        u = (self.c_puct * sqrt_total) * node.priors / (1.0 + N)
+        return int(np.argmax(q_parent + u))
+
+    def _descend(self, node: _Node, board: chess.Board, apply_vl: bool):
+        """Walk to an unexpanded leaf, pushing moves. Returns (leaf_node, path),
+        where path is the list of (node, child_idx) edges traversed."""
+        path: list[tuple[_Node, int]] = []
+        while node.expanded:
+            idx = self._select_idx(node)
+            if apply_vl:
+                # Virtual loss: a virtual *win* in the child's POV looks like a
+                # loss to this node under -Q selection, so concurrent descents in
+                # the batch avoid the path.
+                node.child_N[idx] += 1
+                node.child_W[idx] += 1.0
+            path.append((node, idx))
+            board.push(node.moves[idx])
+            child = node.children[idx]
+            if child is None:
+                child = _Node()
+                node.children[idx] = child
+            node = child
+        return node, path
 
     @staticmethod
-    def _backup_vl(path: list[_Node], leaf_value: float):
-        """Back up a leaf value, undoing the virtual loss applied during descent.
-
-        Descent did ``N += 1; W += 1`` on each path node (a virtual *win* in the
-        node's own POV, which looks like a loss to its parent under the negamax
-        ``-child.Q`` selection, so concurrent descents avoid the path). Here we
-        subtract that +1 back out and apply the real, sign-alternating value. N
-        is left as-is since the virtual-loss pass already counted the visit.
-        """
-        v = leaf_value
-        for node in reversed(path):
-            node.W += v - 1.0
-            v = -v
-
-    def _select_child(self, node: _Node) -> tuple[chess.Move, _Node]:
-        sqrt_total = math.sqrt(node.N)
-        # FPU: value unvisited children relative to the parent's own estimate.
-        fpu_q = (node.Q - self.fpu) if self.fpu is not None else 0.0
-        best_score = -float("inf")
-        best_move = None
-        best_child = None
-        for move, child in node.children.items():
-            # child.Q is from the child's side-to-move POV; negate for the
-            # parent's POV (negamax).
-            u = self.c_puct * child.prior * sqrt_total / (1 + child.N)
-            q = fpu_q if child.N == 0 else -child.Q
-            score = q + u
-            if score > best_score:
-                best_score = score
-                best_move = move
-                best_child = child
-        return best_move, best_child
-
-    def _simulate(self, root: _Node, board: chess.Board):
-        node = root
-        path = [node]
-        pushed = 0
-        while node.expanded:
-            move, child = self._select_child(node)
-            board.push(move)
-            pushed += 1
-            node = child
-            path.append(node)
-
-        term = self._terminal_value(board)
-        value = term if term is not None else self._expand(node, board)
-
-        # Negamax backup: value is from the leaf's side-to-move POV; flip sign
-        # at each step toward the root.
+    def _backup(path: list[tuple[_Node, int]], value: float):
+        """Negamax backup over edges (no virtual loss)."""
         v = value
-        for n in reversed(path):
-            n.N += 1
-            n.W += v
+        for node, idx in reversed(path):
+            node.child_N[idx] += 1
+            node.child_W[idx] += v
             v = -v
 
+    @staticmethod
+    def _backup_vl(path: list[tuple[_Node, int]], value: float):
+        """Backup that undoes the per-edge virtual loss (+1 added during descent)
+        and applies the real, sign-alternating value. N already counted."""
+        v = value
+        for node, idx in reversed(path):
+            node.child_W[idx] += v - 1.0
+            v = -v
+
+    # ── search drivers ───────────────────────────────────────────────────
+    def _simulate(self, root: _Node, board: chess.Board):
+        node, path = self._descend(root, board, apply_vl=False)
+        pushed = len(path)
+        term = self._terminal_value(board)
+        value = term if term is not None else self._expand_leaf(node, board)
+        self._backup(path, value)
         for _ in range(pushed):
             board.pop()
 
     def _run_batch(self, root: _Node, board: chess.Board, batch_n: int):
-        """Collect up to ``batch_n`` leaves (virtual loss applied during descent),
-        evaluate the unique non-terminal ones in a single batched forward, then
-        expand and back them up. This turns ~batch_n synchronous GPU->CPU syncs
-        into one."""
-        leaves = []          # (path, node, key, moves) awaiting network eval
-        items_by_key = {}    # key -> (pos, player, castling, ep, key) for _batch_run
+        """Collect up to ``batch_n`` leaves (virtual loss during descent),
+        evaluate the unique uncached non-terminal ones in one batched forward,
+        then expand and back them up."""
+        leaves = []          # (path, leaf_node, key, moves)
+        items_by_key = {}    # key -> (pos, player, castling, ep, key)
 
         for _ in range(batch_n):
-            node = root
-            path = [node]
-            pushed = 0
-            while node.expanded:
-                move, child = self._select_child(node)
-                board.push(move)
-                pushed += 1
-                node = child
-                path.append(node)
-
-            # Virtual loss: a virtual *win* in each node's own POV (looks like a
-            # loss to its parent under negamax -child.Q selection) so other
-            # descents in this batch avoid re-exploring the same path.
-            for n in path:
-                n.N += 1
-                n.W += 1.0
-
+            node, path = self._descend(root, board, apply_vl=True)
             term = self._terminal_value(board)
             if term is not None:
                 self._backup_vl(path, term)
@@ -197,34 +188,29 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
                 key = chess.polyglot.zobrist_hash(board)
                 moves = list(board.legal_moves)
                 leaves.append((path, node, key, moves))
-                # Only schedule a network eval for positions we haven't already
-                # cached (transpositions, reused subtree, prior moves / games):
-                # the policy+value are reused straight from the transposition
-                # table. Lossless — cached output == what the net would produce.
+                # Reuse cached policy+value (transpositions / reused subtree /
+                # prior moves); only batch positions we haven't evaluated yet.
                 if key in self._tt:
                     self.tt_hits += 1
                 elif key not in items_by_key:
                     pos, player, castling, ep = self._encode_position(board)
                     items_by_key[key] = (pos, player, castling, ep, key)
-
-            for _ in range(pushed):
+            for _ in range(len(path)):
                 board.pop()
 
-        # One batched forward (+ one sync) populates the TT for every position.
         if items_by_key:
-            self._batch_run(list(items_by_key.values()))
+            self._batch_run(list(items_by_key.values()))  # populates self._tt
 
         for path, node, key, moves in leaves:
             logits, value = self._tt[key]
             if not node.expanded:
-                self._expand_from_logits(node, moves, logits)
+                self._expand_node(node, moves, self._compute_priors(moves, logits))
             self._backup_vl(path, value)
 
+    # ── tree reuse ───────────────────────────────────────────────────────
     def _take_reuse_root(self, board: chess.Board) -> _Node | None:
         """Re-root the retained tree to ``board`` if it follows the previous
-        search position by a few plies (the moves actually played). Consumes the
-        stored tree; returns an expanded node to use as root, or None for fresh.
-        """
+        search position by a few plies. Consumes the stored tree."""
         root = self._reuse_root
         self._reuse_root = None
         if root is None or self._reuse_moves is None:
@@ -232,15 +218,20 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         ms = board.move_stack
         rp = len(self._reuse_moves)
         gap = len(ms) - rp
-        # Normal case: our move + opponent reply (gap 2). Allow 1-4 for safety;
-        # require an exact history-prefix match so we never reuse another game.
         if gap < 1 or gap > 4 or list(ms[:rp]) != self._reuse_moves:
             return None
         node = root
         for mv in ms[rp:]:
-            if not (node.expanded and mv in node.children):
+            if not node.expanded:
                 return None
-            node = node.children[mv]
+            try:
+                idx = node.moves.index(mv)
+            except ValueError:
+                return None
+            child = node.children[idx]
+            if child is None or not child.expanded:
+                return None
+            node = child
         return node if node.expanded else None
 
     def predict(self, board: chess.Board) -> tuple[str, float | None]:
@@ -248,15 +239,13 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         self.tt_hits = 0
         self.completed_depth = self.num_simulations
 
+        if not any(board.legal_moves):
+            return chess.Move.null().uci(), 0.0
+
         root = self._take_reuse_root(board) if self.tree_reuse else None
         if root is None:
-            root = _Node(prior=1.0)
-            root_value = self._expand(root, board)
-            if not root.children:
-                return next(iter(board.legal_moves)).uci(), 0.0
-            # Seed the root with one visit so the first PUCT term is well-defined.
-            root.N = 1
-            root.W = root_value
+            root = _Node()
+            self._expand_leaf(root, board)
 
         if self.sim_batch <= 1:
             for _ in range(self.num_simulations):
@@ -268,11 +257,12 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
                 self._run_batch(root, board, n)
                 done += n
 
-        best_move, best_child = max(root.children.items(), key=lambda kv: kv[1].N)
+        best_idx = int(np.argmax(root.child_N))
+        best_move = root.moves[best_idx]
+        n = int(root.child_N[best_idx])
         # Root value from side-to-move POV (negate child's POV).
-        best_value = -best_child.Q
+        best_value = float(-root.child_W[best_idx] / n) if n > 0 else 0.0
 
-        # Retain the tree (and the history it was searched at) for next move.
         if self.tree_reuse:
             self._reuse_root = root
             self._reuse_moves = list(board.move_stack)
@@ -287,7 +277,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("model_dir", nargs="?", default=str(_DEFAULT_RUN))
     parser.add_argument("--sims", type=int, default=800)
-    parser.add_argument("--c-puct", type=float, default=1.5)
+    parser.add_argument("--c-puct", type=float, default=1.0)
     parser.add_argument("--ema", action="store_true")
     args = parser.parse_args()
 

--- a/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
@@ -197,7 +197,13 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
                 key = chess.polyglot.zobrist_hash(board)
                 moves = list(board.legal_moves)
                 leaves.append((path, node, key, moves))
-                if key not in items_by_key:
+                # Only schedule a network eval for positions we haven't already
+                # cached (transpositions, reused subtree, prior moves / games):
+                # the policy+value are reused straight from the transposition
+                # table. Lossless — cached output == what the net would produce.
+                if key in self._tt:
+                    self.tt_hits += 1
+                elif key not in items_by_key:
                     pos, player, castling, ep = self._encode_position(board)
                     items_by_key[key] = (pos, player, castling, ep, key)
 

--- a/src/chesstransformer/models/transformer/pos2move_v2.py
+++ b/src/chesstransformer/models/transformer/pos2move_v2.py
@@ -106,6 +106,9 @@ class ChessGroupedQueryAttention(nn.Module):
         queries = self.q_norm(queries)
         keys_new = self.k_norm(keys_new)
 
+        # Expand K/V to full head count. At this tiny sequence length (67) the
+        # repeat_interleave is cheaper than SDPA's native enable_gqa path, which
+        # falls back to a slower kernel here (measured ~20% slower).
         keys = keys_new.repeat_interleave(self.group_size, dim=1)
         values = values_new.repeat_interleave(self.group_size, dim=1)
 
@@ -187,6 +190,9 @@ class Pos2MoveV2(nn.Module):
 
         self.token_embedding = nn.Embedding(vocab_size, embed_dim)
         self.position_embedding = nn.Embedding(67, embed_dim)  # 64 squares + 3 extra tokens
+        # Static position indices, kept as a buffer so we don't rebuild the
+        # arange (and a host->device copy) on every forward pass.
+        self.register_buffer("pos_index", torch.arange(67), persistent=False)
         self.castling_embedding = nn.Embedding(16, embed_dim)  # 4-bit bitmask: 0-15
         self.en_passant_embedding = nn.Embedding(9, embed_dim)  # 8 files + no en passant (8)
         self.player_embedding = nn.Embedding(2, embed_dim)  # White or Black
@@ -255,7 +261,7 @@ class Pos2MoveV2(nn.Module):
         batch_size = board_tokens.size(0)
 
         token_emb = self.token_embedding(board_tokens)  # (B, 64, D)
-        pos_emb = self.position_embedding(torch.arange(67, device=board_tokens.device))  # (67, D)
+        pos_emb = self.position_embedding(self.pos_index)  # (67, D)
         castling_emb = self.castling_embedding(castling_token).unsqueeze(1)  # (B, 1, D)
         en_passant_emb = self.en_passant_embedding(en_passant_token).unsqueeze(1)  # (B, 1, D)
         player_emb = self.player_embedding(player_token).unsqueeze(1)  # (B, 1, D)


### PR DESCRIPTION
## Summary

Inference-side overhaul of Pos2MoveV2 — **~1550 → ~2075 Elo (+~525), with no retraining** — plus a new default model (v2.1) and the search engine.

## Strength (vs Stockfish, MLE over 140-game gauntlets, skills 0–12)

| Stage | Elo |
|---|---|
| Start (depth-3 alpha-beta) | ~1550 |
| MCTS@400 + compiled inference + v2.1 | ~1793 |
| **+ search tuning (FPU, c_puct, 800 sims)** | **~2075** |

At 800 sims the engine is ~even with skill-12 (~2100) Stockfish (skill 8: 100%, 10: 62.5%, 12: 47.5%).

## What changed

**Search engine**
- **MCTS / PUCT** (`Pos2MoveV2MctsBot`) is the new default — beat the alpha-beta engine ~82% head-to-head. Policy head → priors, value head → leaf scores, most-visited move.
- **Batched-leaf evaluation with virtual loss** — several leaves per network call, amortizing the per-sim GPU→CPU sync (~8× faster: 167→21 ms/move at 200 sims).
- **Search tuning (+~280 Elo, no retraining):** first-play-urgency `fpu=0.2` and `c_puct=1.0` (more exploration / flatter priors both lost). FPU lifts the sims plateau, so the default is **800 sims** (~84 ms/move).
- Alpha-beta engine kept as an alternative, now with **quiescence search** (+~35 Elo) and a Zobrist transposition table.

**Speed (lossless)**
- `torch.compile(mode="reduce-overhead")` + CUDA graphs + bucketed batches → alpha-beta forward ~2.3× faster (77→33 ms/move), move-for-move identical (verified by `scripts/bench_inference.py`).

**Model**
- New `data/models/pos2move_v2.1/` (promoted from `run_021`), now the default weights.

**Tooling / methodology**
- `scripts/bench_inference.py` (speed + lossless golden-move guard), `scripts/engine_match.py` (deterministic engine-vs-engine A/B), `scripts/tune_vs_stockfish.py` (Stockfish sweep).
- **MLE single-Elo estimator** — averaging per-level estimates is biased low (saturated easy levels cap at a low Elo and drag the mean); MLE over all games fixes it.

**API**
- Serves MCTS by default (`ENGINE=mcts`, `MCTS_SIMS=800`); `ENGINE=alphabeta` to switch.

## Verification
- Lossless speedups: `scripts/bench_inference.py --check` (moves identical).
- Strength: `scripts/tune_vs_stockfish.py` gauntlets + `scripts/engine_match.py` head-to-heads (all numbers above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
