### PR TITLE
Policy distillation tooling + negative-result findings

### DIFF
--- a/docs/policy-distillation.md
+++ b/docs/policy-distillation.md
@@ -1,0 +1,64 @@
+# Stockfish policy distillation — findings (negative result)
+
+**TL;DR: post-hoc Stockfish policy distillation does not improve Pos2MoveV2 and
+slightly hurts it. The best distilled model scored ~1650 Elo vs Stockfish, ~125
+Elo *below* the v2.1 baseline (~1775). Do not pursue. Kept here as tooling +
+a documented dead end.**
+
+## Motivation
+
+Probing the v2.1 heads against Stockfish (depth 12) showed an asymmetry:
+
+| Head | Quality vs Stockfish |
+|---|---|
+| Value | r ≈ 0.97, sign-agreement 95%, MAE 0.12 — near-ceiling |
+| Policy | top-1 ≈ 52%, top-3 ≈ 79% — the weaker head |
+
+A uniform-prior ablation (real policy beat uniform 16–0 in MCTS) confirmed the
+policy is load-bearing. Hypothesis: distilling a sharper policy from Stockfish
+would raise strength.
+
+## What we tried
+
+`scripts/gen_sf_policy_labels.py` → Stockfish `multipv` soft labels over the
+64×73 action planes (raw centipawns stored so the softmax temperature is tunable
+at train time). `scripts/distill_policy.py` → KL-divergence distillation with the
+value head pinned to a frozen teacher. `scripts/eval_policy.py` → apples-to-apples
+held-out policy comparison (top-1/top-3/cp-loss vs Stockfish).
+
+Configs swept: 24k and **200k** labels (depth 12); full fine-tune, frozen-backbone
+(head-only), and gentle low-lr; temperatures 40–100 cp.
+
+## Results
+
+Held-out policy (vs Stockfish, depth 12):
+
+| Model | top-1 | top-3 | cp lost |
+|---|---|---|---|
+| v2.1 baseline | 52–53% | 79% | 23–27c |
+| distill-head (24k, frozen backbone) | 54.0% | 80.7% | 39c |
+| distill (200k, gentle) | 49.2% | 76.8% | 33c |
+| distill (24k, full FT) | 43.0% | 72.3% | 51c |
+
+Stockfish gauntlet (MCTS @ 400 sims, 20 games/level, skills 0–12):
+
+| Model | Weighted Elo | skill 8 | skill 10 | skill 12 |
+|---|---|---|---|---|
+| **v2.1** | **~1775** | 62.5% | 40% | 27.5% |
+| distill-head (best by policy metric) | **~1650** | 52.5% | 20% | 10% |
+
+## Why it failed
+
+- **More data didn't help** (24k → 200k unchanged) → the policy is near the
+  11.7M model's capacity ceiling, not data-limited.
+- **top-1/top-3 is a misleading proxy.** distill-head had marginally better
+  top-k but worse **cp-loss** (39c vs ~25c). Game strength tracks cp-loss (the
+  quality of the chosen move), not top-k match rate. Distilling toward
+  Stockfish's distribution nudged "name the popular move" up while making the
+  model's wrong moves *more* wrong — and that lost ~125 Elo, worst at high skill.
+
+## Takeaway
+
+A stronger policy needs **more model capacity or a from-scratch retrain with
+Stockfish targets blended into the loss**, not a post-hoc graft. The value head
+is already excellent. The proven strength lever is **search (MCTS sims)**.

--- a/scripts/distill_policy.py
+++ b/scripts/distill_policy.py
@@ -1,0 +1,184 @@
+"""Distill a sharper policy into Pos2MoveV2 from Stockfish soft labels.
+
+Fine-tunes the model with a KL-divergence loss toward the Stockfish move
+distribution (from `gen_sf_policy_labels.py`). The value head is pinned to a
+frozen teacher copy via an MSE preservation term, so the (already strong) value
+estimates don't regress while the policy improves.
+
+Usage
+-----
+    uv run python scripts/distill_policy.py \
+        --labels data/distill/sf_policy_poc.npz \
+        --base data/models/pos2move_v2.1 \
+        --out data/models/pos2move_v2.1-distill \
+        --epochs 6 --lr 2e-4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+from safetensors.torch import save_file
+from torch.utils.data import DataLoader, Dataset
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from chesstransformer.models.transformer.pos2move_v2 import NUM_ACTION_PLANES, Pos2MoveV2
+
+ACTION_DIM = 64 * NUM_ACTION_PLANES  # 4672
+
+
+class SFLabelDataset(Dataset):
+    def __init__(self, npz_path: str, temp: float = 50.0):
+        d = np.load(npz_path)
+        self.tokens = d["tokens"].astype(np.int64)
+        self.player = d["player"].astype(np.int64)
+        self.castling = d["castling"].astype(np.int64)
+        self.ep = d["ep"].astype(np.int64)
+        self.tgt_idx = d["tgt_idx"].astype(np.int64)
+        self.temp = temp
+        # New format stores raw centipawns (temperature applied here); old PoC
+        # files stored pre-softmaxed probabilities.
+        if "tgt_cp" in d.files:
+            self.tgt_cp = d["tgt_cp"].astype(np.float32)
+            self.mode = "cp"
+        else:
+            self.tgt_prob = d["tgt_prob"].astype(np.float32)
+            self.mode = "prob"
+
+    def __len__(self):
+        return len(self.tokens)
+
+    def __getitem__(self, i):
+        target = torch.zeros(ACTION_DIM, dtype=torch.float32)
+        idx = self.tgt_idx[i]
+        valid = idx >= 0
+        if self.mode == "cp":
+            cp = self.tgt_cp[i][valid] / self.temp
+            cp = cp - cp.max()
+            w = np.exp(cp); w = w / w.sum()
+        else:
+            w = self.tgt_prob[i][valid]
+        target[idx[valid]] = torch.from_numpy(w.astype(np.float32))
+        return (
+            torch.from_numpy(self.tokens[i]),
+            int(self.player[i]), int(self.castling[i]), int(self.ep[i]),
+            target,
+        )
+
+
+def load_model(base_dir: str, device: str) -> Pos2MoveV2:
+    base = Path(base_dir)
+    config = json.loads((base / "model_config.json").read_text())
+    model = Pos2MoveV2(**config)
+    with safe_open(str(base / "model.safetensors"), framework="pt", device="cpu") as f:
+        state = {k: f.get_tensor(k) for k in f.keys()}
+    if any(k.startswith("_orig_mod.") for k in state):
+        state = {k.replace("_orig_mod.", ""): v for k, v in state.items()}
+    model.load_state_dict(state)
+    return model.to(device)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--labels", required=True)
+    p.add_argument("--base", default="data/models/pos2move_v2.1")
+    p.add_argument("--out", required=True)
+    p.add_argument("--epochs", type=int, default=6)
+    p.add_argument("--lr", type=float, default=2e-4)
+    p.add_argument("--batch", type=int, default=256)
+    p.add_argument("--value-pin", type=float, default=1.0, help="weight on value-preservation MSE")
+    p.add_argument("--val-frac", type=float, default=0.05)
+    p.add_argument("--freeze-backbone", action="store_true",
+                   help="train only the policy head (move_head); backbone + value head frozen "
+                        "so value output is identical and policy can't overfit the backbone")
+    p.add_argument("--temp", type=float, default=50.0,
+                   help="cp softmax temperature applied to raw-cp labels (lower = sharper)")
+    args = p.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(0)
+
+    ds = SFLabelDataset(args.labels, temp=args.temp)
+    n_val = max(1, int(len(ds) * args.val_frac))
+    n_train = len(ds) - n_val
+    train_ds, val_ds = torch.utils.data.random_split(
+        ds, [n_train, n_val], generator=torch.Generator().manual_seed(0)
+    )
+    train_dl = DataLoader(train_ds, batch_size=args.batch, shuffle=True, drop_last=True)
+    val_dl = DataLoader(val_ds, batch_size=args.batch)
+    print(f"Labels: {len(ds)}  (train {n_train} / val {n_val})")
+
+    student = load_model(args.base, device)
+    teacher = load_model(args.base, device)
+    teacher.eval()
+    for pr in teacher.parameters():
+        pr.requires_grad_(False)
+
+    if args.freeze_backbone:
+        for name, pr in student.named_parameters():
+            pr.requires_grad_(name.startswith("move_head"))
+        trainable = [pr for pr in student.parameters() if pr.requires_grad]
+        print(f"Frozen backbone: training {sum(p.numel() for p in trainable)} params (move_head only)")
+    else:
+        trainable = list(student.parameters())
+    opt = torch.optim.AdamW(trainable, lr=args.lr, weight_decay=0.01)
+
+    def run_batch(batch, train: bool):
+        tokens, player, castling, ep, target = batch
+        tokens = tokens.to(device); player = player.to(device)
+        castling = castling.to(device); ep = ep.to(device); target = target.to(device)
+        move_logits, value = student(tokens, player, castling, ep)
+        log_pred = F.log_softmax(move_logits.view(move_logits.size(0), -1).float(), dim=-1)
+        kl = F.kl_div(log_pred, target, reduction="batchmean")
+        with torch.no_grad():
+            _, v_teacher = teacher(tokens, player, castling, ep)
+        vpin = F.mse_loss(value.float(), v_teacher.float())
+        loss = kl + args.value_pin * vpin
+        # metric: top-1 agreement with the SF argmax target
+        with torch.no_grad():
+            pred_top = log_pred.argmax(dim=-1)
+            tgt_top = target.argmax(dim=-1)
+            top1 = (pred_top == tgt_top).float().mean()
+        return loss, kl.detach(), vpin.detach(), top1
+
+    student.train()
+    for epoch in range(1, args.epochs + 1):
+        tot = 0.0; nb = 0
+        for batch in train_dl:
+            opt.zero_grad()
+            loss, kl, vpin, _ = run_batch(batch, True)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(student.parameters(), 1.0)
+            opt.step()
+            tot += loss.item(); nb += 1
+        # validation
+        student.eval()
+        with torch.no_grad():
+            vkl = vt1 = vvp = 0.0; vb = 0
+            for batch in val_dl:
+                _, kl, vpin, top1 = run_batch(batch, False)
+                vkl += kl.item(); vt1 += top1.item(); vvp += vpin.item(); vb += 1
+        student.train()
+        print(f"epoch {epoch}: train_loss={tot/nb:.4f}  val_kl={vkl/vb:.4f}  "
+              f"val_top1(vs SF)={vt1/vb:.1%}  val_vpin={vvp/vb:.5f}")
+
+    # Save
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    student.eval()
+    save_file(student.state_dict(), str(out / "model.safetensors"))
+    shutil.copy(Path(args.base) / "model_config.json", out / "model_config.json")
+    print(f"Saved distilled model to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_policy.py
+++ b/scripts/eval_policy.py
@@ -1,0 +1,135 @@
+"""Compare the policy head of one or more models against Stockfish, on a fixed,
+held-out set of positions (apples-to-apples).
+
+Samples positions from Lichess (held-out seed), computes each position's
+Stockfish best move once, then for each model reports policy top-1 / top-3
+agreement with Stockfish (legal-move masked) and the mean centipawn lost by the
+model's top move.
+
+Usage
+-----
+    uv run python scripts/eval_policy.py \
+        --models data/models/pos2move_v2.1 data/models/pos2move_v2.1-distill \
+        --positions 300 --depth 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from safetensors import safe_open
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import chess
+import chess.engine
+
+from chesstransformer.datasets.h5_lichess_dataset import HDF5ChessDataset
+from chesstransformer.models.tokenizer.alphazero_move_encoder import move_to_action_plane
+from chesstransformer.models.tokenizer.position_tokenizer import PostionTokenizer
+from chesstransformer.models.transformer.pos2move_v2 import Pos2MoveV2
+
+TOK = PostionTokenizer()
+
+
+def load_model(base_dir: str, device: str):
+    base = Path(base_dir)
+    config = json.loads((base / "model_config.json").read_text())
+    model = Pos2MoveV2(**config)
+    with safe_open(str(base / "model.safetensors"), framework="pt", device="cpu") as f:
+        state = {k: f.get_tensor(k) for k in f.keys()}
+    if any(k.startswith("_orig_mod.") for k in state):
+        state = {k.replace("_orig_mod.", ""): v for k, v in state.items()}
+    model.load_state_dict(state)
+    return model.bfloat16().to(device).eval()
+
+
+@torch.no_grad()
+def model_policy_order(model, board, device):
+    """Return legal moves ordered by the model's policy (descending)."""
+    tok = torch.tensor(TOK.encode(board), dtype=torch.long, device=device).unsqueeze(0)
+    player = torch.tensor([int(board.turn)], dtype=torch.long, device=device)
+    castling = 0
+    if board.has_kingside_castling_rights(chess.WHITE): castling |= 1
+    if board.has_queenside_castling_rights(chess.WHITE): castling |= 2
+    if board.has_kingside_castling_rights(chess.BLACK): castling |= 4
+    if board.has_queenside_castling_rights(chess.BLACK): castling |= 8
+    ep = chess.square_file(board.ep_square) if board.has_legal_en_passant() else 8
+    castling_t = torch.tensor([castling], dtype=torch.long, device=device)
+    ep_t = torch.tensor([ep], dtype=torch.long, device=device)
+    logits, _ = model(tok, player, castling_t, ep_t)
+    logits = logits[0].float().cpu().numpy()
+    moves = list(board.legal_moves)
+    scores = [logits[m.from_square, move_to_action_plane(m.from_square, m.to_square, m.promotion)] for m in moves]
+    return [m for _, m in sorted(zip(scores, moves), key=lambda x: -x[0])]
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--models", nargs="+", required=True)
+    p.add_argument("--h5", default="data/elite_db.h5")
+    p.add_argument("--positions", type=int, default=300)
+    p.add_argument("--depth", type=int, default=12)
+    p.add_argument("--seed", type=int, default=99999, help="held-out sampling seed")
+    p.add_argument("--sf-path", default="/usr/games/stockfish")
+    args = p.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    ds = HDF5ChessDataset(args.h5, sample_weighting="uniform")
+    rng = np.random.default_rng(args.seed)
+
+    # Build a fixed held-out set: (board, sf_best_move, sf_eval_after_best)
+    eng = chess.engine.SimpleEngine.popen_uci(args.sf_path)
+    eng.configure({"Threads": 1, "Hash": 64})
+    positions = []
+    while len(positions) < args.positions:
+        idx = int(rng.integers(0, len(ds)))
+        moves = ds._get_game_moves(ds.valid_game_indices[idx])
+        if len(moves) <= 8:
+            continue
+        ply = int(rng.integers(6, len(moves) - 1))
+        b = chess.Board()
+        ok = True
+        for i in range(ply):
+            try:
+                b.push(chess.Move.from_uci(ds._decode_move_token(int(moves[i]))))
+            except (ValueError, AssertionError):
+                ok = False; break
+        if not ok or b.is_game_over() or not any(b.legal_moves):
+            continue
+        info = eng.analyse(b, chess.engine.Limit(depth=args.depth))
+        positions.append((b.fen(), info["pv"][0].uci()))
+
+    def eval_after(board, move, depth=10):
+        board.push(move)
+        sc = -eng.analyse(board, chess.engine.Limit(depth=depth))["score"].relative.score(mate_score=2000)
+        board.pop()
+        return sc
+
+    print(f"Held-out positions: {len(positions)} (depth {args.depth})\n")
+    print(f"{'model':<40}{'top1':>8}{'top3':>8}{'cp_loss':>9}")
+    print("-" * 65)
+    for mdir in args.models:
+        model = load_model(mdir, device)
+        top1 = top3 = 0; cp = []
+        for fen, sf_best in positions:
+            b = chess.Board(fen)
+            order = model_policy_order(model, b, device)
+            best = order[0].uci()
+            top3set = {m.uci() for m in order[:3]}
+            top1 += best == sf_best
+            top3 += sf_best in top3set
+            cp.append(eval_after(b, chess.Move.from_uci(sf_best)) - eval_after(b, order[0]))
+        n = len(positions)
+        print(f"{Path(mdir).name:<40}{top1/n:>7.1%}{top3/n:>8.1%}{np.mean(cp):>8.0f}c")
+        del model
+    eng.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_sf_policy_labels.py
+++ b/scripts/gen_sf_policy_labels.py
@@ -1,0 +1,198 @@
+"""Generate Stockfish soft-policy distillation labels from Lichess positions.
+
+For each sampled position we ask Stockfish for its top-K moves (multipv) and turn
+the centipawn evals into a soft target distribution over the AlphaZero 64x73
+action planes (softmax over cp with a temperature). These targets feed the
+trainer's existing KL-divergence policy loss to distill a sharper policy into
+the v2.1 model.
+
+Stockfish is the bottleneck, so work is split across worker processes (each with
+its own engine); shards are merged into a single .npz.
+
+Usage
+-----
+    uv run python scripts/gen_sf_policy_labels.py \
+        --h5 data/elite_db.h5 --out data/distill/sf_policy_poc.npz \
+        --num 25000 --depth 10 --multipv 8 --workers 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import chess
+import chess.engine
+
+from chesstransformer.datasets.h5_lichess_dataset import HDF5ChessDataset
+from chesstransformer.models.tokenizer.alphazero_move_encoder import (
+    NUM_ACTION_PLANES,
+    move_to_action_plane,
+)
+from chesstransformer.models.tokenizer.position_tokenizer import PostionTokenizer
+
+# Worker globals (initialized once per process).
+_DS: HDF5ChessDataset | None = None
+_ENG: chess.engine.SimpleEngine | None = None
+_TOK = PostionTokenizer()
+
+
+def _encode_state(board: chess.Board):
+    castling = 0
+    if board.has_kingside_castling_rights(chess.WHITE):
+        castling |= 1
+    if board.has_queenside_castling_rights(chess.WHITE):
+        castling |= 2
+    if board.has_kingside_castling_rights(chess.BLACK):
+        castling |= 4
+    if board.has_queenside_castling_rights(chess.BLACK):
+        castling |= 8
+    ep = chess.square_file(board.ep_square) if board.has_legal_en_passant() else 8
+    return int(board.turn), castling, ep
+
+
+def _sample_board(rng: np.random.Generator, min_ply: int) -> chess.Board | None:
+    """Replay a random game to a random ply and return the board."""
+    idx = int(rng.integers(0, len(_DS)))
+    game_idx = _DS.valid_game_indices[idx]
+    moves = _DS._get_game_moves(game_idx)
+    n = len(moves)
+    if n <= min_ply + 1:
+        return None
+    target_ply = int(rng.integers(min_ply, n - 1))
+    board = chess.Board()
+    for i in range(target_ply):
+        try:
+            board.push(chess.Move.from_uci(_DS._decode_move_token(int(moves[i]))))
+        except (ValueError, AssertionError):
+            return None
+    if board.is_game_over() or not any(board.legal_moves):
+        return None
+    return board
+
+
+def _worker_init(h5: str, sf_path: str, depth: int):
+    global _DS, _ENG
+    _DS = HDF5ChessDataset(h5, sample_weighting="uniform")
+    _ENG = chess.engine.SimpleEngine.popen_uci(sf_path)
+    _ENG.configure({"Threads": 1, "Hash": 32})
+
+
+def _gen_shard(args_tuple):
+    """Generate `count` labelled positions in this worker; return arrays."""
+    seed, count, depth, multipv, temp, min_ply = args_tuple
+    rng = np.random.default_rng(seed)
+    tokens, players, castlings, eps = [], [], [], []
+    tgt_idx, tgt_prob = [], []
+
+    made = 0
+    attempts = 0
+    while made < count and attempts < count * 6:
+        attempts += 1
+        board = _sample_board(rng, min_ply)
+        if board is None:
+            continue
+        try:
+            info = _ENG.analyse(
+                board, chess.engine.Limit(depth=depth), multipv=multipv
+            )
+        except chess.engine.EngineError:
+            continue
+
+        idxs, cps = [], []
+        for line in info:
+            pv = line.get("pv")
+            if not pv:
+                continue
+            mv = pv[0]
+            plane = move_to_action_plane(mv.from_square, mv.to_square, mv.promotion)
+            idxs.append(mv.from_square * NUM_ACTION_PLANES + plane)
+            cps.append(float(line["score"].relative.score(mate_score=2000)))
+        if not idxs:
+            continue
+
+        # Store RAW centipawns (relative to the best move = 0), so the softmax
+        # temperature can be chosen at training time without regenerating.
+        cps = np.array(cps, dtype=np.float64)
+        cps -= cps.max()  # best move -> 0, others <= 0
+        k = multipv
+        pad_idx = np.full(k, -1, dtype=np.int16)
+        pad_cp = np.full(k, -30000.0, dtype=np.float32)  # pad -> softmax ~0
+        m = min(len(idxs), k)
+        pad_idx[:m] = np.array(idxs[:m], dtype=np.int16)
+        pad_cp[:m] = cps[:m].astype(np.float32)
+
+        player, castling, ep = _encode_state(board)
+        tokens.append(np.array(_TOK.encode(board), dtype=np.int8))
+        players.append(player)
+        castlings.append(castling)
+        eps.append(ep)
+        tgt_idx.append(pad_idx)
+        tgt_prob.append(pad_cp)
+        made += 1
+
+    if made == 0:
+        return None
+    return (
+        np.stack(tokens), np.array(players, np.int8), np.array(castlings, np.int8),
+        np.array(eps, np.int8), np.stack(tgt_idx), np.stack(tgt_prob),
+    )
+
+
+def main():
+    import multiprocessing as mp
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--h5", default="data/elite_db.h5")
+    p.add_argument("--out", required=True)
+    p.add_argument("--num", type=int, default=25000)
+    p.add_argument("--depth", type=int, default=10)
+    p.add_argument("--multipv", type=int, default=8)
+    p.add_argument("--temp", type=float, default=100.0, help="cp softmax temperature")
+    p.add_argument("--min-ply", type=int, default=6)
+    p.add_argument("--workers", type=int, default=min(12, os.cpu_count() or 4))
+    p.add_argument("--sf-path", default="/usr/games/stockfish")
+    args = p.parse_args()
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+
+    per = args.num // args.workers
+    tasks = [
+        (1000 + i, per, args.depth, args.multipv, args.temp, args.min_ply)
+        for i in range(args.workers)
+    ]
+    print(f"Generating ~{per * args.workers} labels across {args.workers} workers "
+          f"(depth={args.depth}, multipv={args.multipv}, temp={args.temp}cp)...")
+
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(
+        processes=args.workers,
+        initializer=_worker_init,
+        initargs=(args.h5, args.sf_path, args.depth),
+    ) as pool:
+        shards = pool.map(_gen_shard, tasks)
+
+    shards = [s for s in shards if s is not None]
+    tokens = np.concatenate([s[0] for s in shards])
+    players = np.concatenate([s[1] for s in shards])
+    castlings = np.concatenate([s[2] for s in shards])
+    eps = np.concatenate([s[3] for s in shards])
+    tgt_idx = np.concatenate([s[4] for s in shards])
+    tgt_prob = np.concatenate([s[5] for s in shards])
+
+    np.savez_compressed(
+        args.out, tokens=tokens, player=players, castling=castlings, ep=eps,
+        tgt_idx=tgt_idx, tgt_cp=tgt_prob,  # tgt_prob holds RAW cp (see _gen_shard)
+        meta=np.array([args.depth, args.multipv, args.temp], dtype=np.float32),
+    )
+    print(f"Saved {len(tokens)} labelled positions to {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Reusable tooling for **Stockfish policy distillation**, plus documentation of a **negative result**: post-hoc distillation does **not** improve Pos2MoveV2 and slightly hurts it.

Stacked on #15 (`feat/v2.1-mcts-inference`); this PR's diff is only the distillation tooling.

## Result

| Model (MCTS @ 400) | Elo vs Stockfish |
|---|---|
| v2.1 (baseline) | ~1775 |
| best distilled (distill-head) | **~1650** (−125) |

Tried 24k and 200k (depth-12) labels, full / head-only / gentle fine-tunes, temps 40–100. None beat baseline; more data didn't help. Held-out top-1/top-3 was a misleading proxy — the distilled model had marginally better top-k but worse **cp-loss**, and game strength follows cp-loss.

**Conclusion:** the policy is near the 11.7M model's capacity ceiling; a stronger policy needs more capacity / a from-scratch retrain with SF targets in the loss, not a post-hoc graft. The value head is already strong (r≈0.97); the proven lever is search (MCTS sims).

## What's here
- `scripts/gen_sf_policy_labels.py` — multiprocess SF multipv label gen (raw cp stored → tunable temperature at train time).
- `scripts/distill_policy.py` — KL distillation, value-head pinned to frozen teacher, optional `--freeze-backbone`.
- `scripts/eval_policy.py` — held-out policy top-1/top-3/cp-loss vs Stockfish, across models.
- `docs/policy-distillation.md` — full methodology, results, and why it failed.

No model weights or label files are committed (dead-end artifacts deleted). Kept as tooling + a documented dead end so this isn't re-attempted blindly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)