### PR TITLE
Playable Gradio Space (CPU) for browser demo

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -1,0 +1,90 @@
+name: Deploy HF Space
+
+# Pushes the assembled Gradio Space (hf_space/) to a Hugging Face Space using an
+# OIDC "trusted publisher" — no HF_TOKEN secret stored in GitHub.
+#
+# One-time setup (see hf_space/DEPLOY.md):
+#   1. Create the Space on HF: spaces/<you>/chesstransformer (SDK: Gradio, CPU).
+#   2. On that Space → Settings → Trusted Publishers, add provider GitHub Actions:
+#        repository = tchauffi/ChessTransformer
+#        ref        = refs/heads/main
+#        workflow   = deploy-hf-space.yml
+#   3. Set the repo variable HF_SPACE_REPO (Settings → Secrets and variables →
+#      Actions → Variables) to "<you>/chesstransformer" if it differs from the
+#      default below.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "hf_space/**"
+      - "src/chesstransformer/**"
+      - "data/models/pos2move_v2.1/**"
+      - ".github/workflows/deploy-hf-space.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required to mint the GitHub OIDC token
+      contents: read
+    env:
+      HF_SPACE_REPO: ${{ vars.HF_SPACE_REPO || 'tchauffi/chesstransformer' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true   # materialize the model weights (stored via Git LFS)
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - run: pip install --upgrade "huggingface_hub>=1.18.0"
+
+      - name: Assemble the Space bundle
+        run: bash hf_space/prepare.sh
+
+      - name: Exchange GitHub OIDC token for a Hub token
+        run: |
+          set -euo pipefail
+          RESOURCE="spaces/${HF_SPACE_REPO}"
+
+          ID_TOKEN=$(curl -sSf \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://huggingface.co" \
+            | jq -r .value)
+
+          HEADERS=$(mktemp); BODY=$(mktemp)
+          STATUS=$(curl -sS -D "$HEADERS" -o "$BODY" -w '%{http_code}' \
+            -X POST "https://huggingface.co/oauth/token" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg t "$ID_TOKEN" --arg r "$RESOURCE" \
+                  '{
+                    grant_type:         "urn:ietf:params:oauth:grant-type:token-exchange",
+                    subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
+                    subject_token:      $t,
+                    resource:           $r
+                  }')")
+
+          if [ "$STATUS" -ne 200 ]; then
+            REQUEST_ID=$(grep -i '^x-request-id:' "$HEADERS" | sed 's/.*: *//' | tr -d '\r')
+            echo "::error::Token exchange failed with HTTP $STATUS (x-request-id: ${REQUEST_ID:-unknown})"
+            cat "$BODY"
+            exit 1
+          fi
+
+          HF_TOKEN=$(jq -r .access_token "$BODY")
+          echo "::add-mask::$HF_TOKEN"
+          DELIM="EOF_$(openssl rand -hex 16)"
+          {
+            echo "HF_TOKEN<<$DELIM"
+            echo "$HF_TOKEN"
+            echo "$DELIM"
+          } >> "$GITHUB_ENV"
+
+      - name: Upload to the Space
+        run: |
+          hf upload "$HF_SPACE_REPO" hf_space/space_build . \
+            --repo-type space \
+            --commit-message "Deploy from ${GITHUB_SHA::7}"

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write   # required to mint the GitHub OIDC token
       contents: read
     env:
-      HF_SPACE_REPO: ${{ vars.HF_SPACE_REPO || 'tchauffi/chesstransformer' }}
+      HF_SPACE_REPO: ${{ vars.HF_SPACE_REPO || 'tchauffi/ChessTransformer' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,6 @@ next-env.d.ts
 # Data files
 data/raw/
 *.h5
+
+# HF Space build artifact (assembled by hf_space/prepare.sh)
+hf_space/space_build/

--- a/hf_space/DEPLOY.md
+++ b/hf_space/DEPLOY.md
@@ -12,33 +12,43 @@ uv run python hf_space/app.py
 # open the printed http://127.0.0.1:7860
 ```
 
-## Deploy to Hugging Face Spaces
+## Deploy via GitHub Actions (recommended — no stored token)
 
-1. **Create a Space**: https://huggingface.co/new-space → SDK **Gradio**, hardware
-   **CPU basic** (free). Note its git URL, e.g.
-   `https://huggingface.co/spaces/<you>/chesstransformer`.
+Uses HF [Trusted Publishers](https://huggingface.co/docs/hub/trusted-publishers):
+the CI job proves its identity with a short-lived GitHub OIDC token and exchanges
+it for a 1-hour HF token. Nothing to store or rotate. Workflow:
+`.github/workflows/deploy-hf-space.yml`.
 
-2. **Assemble the deployable bundle** (vendors the package + weights):
+1. **Create the Space**: https://huggingface.co/new-space → SDK **Gradio**,
+   hardware **CPU basic** (free), name it `chesstransformer`.
 
-   ```bash
-   bash hf_space/prepare.sh        # writes hf_space/space_build/
-   ```
+2. **Register this repo as a trusted publisher** on the Space →
+   *Settings → Trusted Publishers* → provider **GitHub Actions**:
+   - `repository` = `tchauffi/ChessTransformer`
+   - `ref` = `refs/heads/main`
+   - `workflow` = `deploy-hf-space.yml`
 
-3. **Push it to the Space:**
+3. If your HF username isn't `tchauffi`, set the repo variable **`HF_SPACE_REPO`**
+   (GitHub → Settings → Secrets and variables → Actions → Variables) to
+   `<you>/chesstransformer`.
 
-   ```bash
-   cd hf_space/space_build
-   git init && git lfs install
-   git add -A && git commit -m "ChessTransformer playable demo"
-   git remote add space https://huggingface.co/spaces/<you>/chesstransformer
-   git push --force space main
-   ```
+4. **Merge to `main`.** The workflow runs on any push touching `hf_space/**`,
+   the package, or the v2.1 weights — or trigger it manually from the Actions tab
+   (*Run workflow*). It assembles the bundle (`prepare.sh`) and uploads it.
 
-   (You'll need a HF token with write access; `huggingface-cli login` once.)
+The Space builds and goes live at `https://huggingface.co/spaces/<you>/chesstransformer`
+(first build takes a few minutes: torch CPU + gradio).
 
-4. The Space builds and goes live at
-   `https://huggingface.co/spaces/<you>/chesstransformer`. First build takes a
-   few minutes (installing torch CPU + gradio).
+## Deploy manually (alternative — needs a write token)
+
+```bash
+bash hf_space/prepare.sh                       # writes hf_space/space_build/
+cd hf_space/space_build
+git init && git lfs install
+git add -A && git commit -m "ChessTransformer playable demo"
+git remote add space https://huggingface.co/spaces/<you>/chesstransformer
+git push --force space main                    # huggingface-cli login first
+```
 
 ## Notes
 

--- a/hf_space/DEPLOY.md
+++ b/hf_space/DEPLOY.md
@@ -1,0 +1,52 @@
+# Deploying the ChessTransformer Space
+
+A self-contained Gradio Space that lets anyone play the bot in the browser, on
+CPU — no GPU, no signup. This removes the "can't try it out" barrier that gets
+Show HN posts flagged.
+
+## Test locally first
+
+```bash
+# from the repo root (uses local weights + installed package)
+uv run python hf_space/app.py
+# open the printed http://127.0.0.1:7860
+```
+
+## Deploy to Hugging Face Spaces
+
+1. **Create a Space**: https://huggingface.co/new-space → SDK **Gradio**, hardware
+   **CPU basic** (free). Note its git URL, e.g.
+   `https://huggingface.co/spaces/<you>/chesstransformer`.
+
+2. **Assemble the deployable bundle** (vendors the package + weights):
+
+   ```bash
+   bash hf_space/prepare.sh        # writes hf_space/space_build/
+   ```
+
+3. **Push it to the Space:**
+
+   ```bash
+   cd hf_space/space_build
+   git init && git lfs install
+   git add -A && git commit -m "ChessTransformer playable demo"
+   git remote add space https://huggingface.co/spaces/<you>/chesstransformer
+   git push --force space main
+   ```
+
+   (You'll need a HF token with write access; `huggingface-cli login` once.)
+
+4. The Space builds and goes live at
+   `https://huggingface.co/spaces/<you>/chesstransformer`. First build takes a
+   few minutes (installing torch CPU + gradio).
+
+## Notes
+
+- **Strength vs speed**: the slider controls MCTS sims/move. Default 200
+  (~1.5s/move on the free 2-vCPU tier, ~1725 Elo). Full strength is 800 sims
+  (~2100 Elo) but slower on CPU.
+- **Weights** are bundled into the Space (≈45 MB, via LFS). If you'd rather not
+  bundle them, set the `MODEL_PATH` env var on the Space, or rely on the
+  app's GitHub-LFS download fallback (slower cold start).
+- Once live, update the GitHub README's Demo section with the Space link and
+  it's ready for a (re-)Show HN.

--- a/hf_space/README.md
+++ b/hf_space/README.md
@@ -1,0 +1,28 @@
+---
+title: ChessTransformer
+emoji: ♟️
+colorFrom: indigo
+colorTo: gray
+sdk: gradio
+sdk_version: 5.49.0
+app_file: app.py
+pinned: false
+license: mit
+short_description: Play a chess transformer trained only on human games
+---
+
+# ♟️ ChessTransformer
+
+Play an **11.7M-parameter transformer trained only on human games** (no self-play,
+no reinforcement learning), playing via AlphaZero-style MCTS. At full strength it
+reaches **~2100 Elo** against Stockfish; this Space runs on CPU at a lower
+simulation count so moves come back in ~1–2s.
+
+You play **White** — drag a piece and the bot replies automatically. Use the
+slider to trade strength for speed.
+
+Code, weights, and the training pipeline: **https://github.com/tchauffi/ChessTransformer**
+
+> This `README.md` is the Space config. The deployable Space is assembled by
+> `prepare.sh` (see `DEPLOY.md`) — it bundles `app.py`, this file, the slim
+> `requirements.txt`, the `chesstransformer` package source, and the model weights.

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -1,0 +1,145 @@
+"""ChessTransformer — Hugging Face Space (Gradio).
+
+Play the transformer chess engine in the browser. Runs on CPU: the model is
+only 11.7M params, so MCTS at a modest sim count returns a move in ~1-2s.
+
+Weights are resolved in this order:
+  1. ``MODEL_PATH`` env var (a checkpoint dir with model.safetensors + config)
+  2. a ``model/`` dir next to this file (how ``prepare.sh`` ships the Space)
+  3. the repo's ``data/models/pos2move_v2.1`` (for local dev runs)
+  4. download from GitHub (LFS media) as a last resort
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import chess
+import gradio as gr
+from gradio_chessboard import Chessboard
+
+# ── make `chesstransformer` importable ──────────────────────────────────────
+# On the Space the package is vendored next to this file (cwd is on sys.path).
+# For local dev runs from the repo, add the repo's src/ to the path.
+_repo_src = Path(__file__).resolve().parents[1] / "src"
+if (_repo_src / "chesstransformer").exists():
+    sys.path.insert(0, str(_repo_src))
+
+from chesstransformer.bots import Pos2MoveV2MctsBot  # noqa: E402
+
+START_FEN = chess.STARTING_FEN
+DEFAULT_SIMS = int(os.environ.get("MCTS_SIMS", "200"))
+
+# GitHub locations for the last-resort weight download.
+_GH = "tchauffi/ChessTransformer"
+_BRANCH = os.environ.get("MODEL_BRANCH", "main")
+_RAW = f"https://raw.githubusercontent.com/{_GH}/{_BRANCH}/data/models/pos2move_v2.1"
+_LFS = f"https://media.githubusercontent.com/media/{_GH}/{_BRANCH}/data/models/pos2move_v2.1"
+
+
+def _download_weights() -> str:
+    import urllib.request
+
+    dest = Path("/tmp/pos2move_v2.1")
+    dest.mkdir(parents=True, exist_ok=True)
+    for fname, url in [("model_config.json", f"{_RAW}/model_config.json"),
+                       ("model.safetensors", f"{_LFS}/model.safetensors")]:
+        out = dest / fname
+        if not out.exists():
+            print(f"Downloading {fname} …")
+            urllib.request.urlretrieve(url, out)
+    return str(dest)
+
+
+def resolve_model_dir() -> str:
+    env = os.environ.get("MODEL_PATH")
+    if env and (Path(env) / "model.safetensors").exists():
+        return env
+    for cand in (
+        Path(__file__).resolve().parent / "model",
+        Path("model"),
+        Path(__file__).resolve().parents[1] / "data" / "models" / "pos2move_v2.1",
+    ):
+        if (cand / "model.safetensors").exists():
+            return str(cand)
+    return _download_weights()
+
+
+# ── load the bot once (CPU, no compile) ─────────────────────────────────────
+MODEL_DIR = resolve_model_dir()
+bot = Pos2MoveV2MctsBot(
+    model_dir=MODEL_DIR,
+    num_simulations=DEFAULT_SIMS,
+    device="cpu",
+    compile=False,
+    time_limit=0.0,
+)
+
+
+def _result_text(board: chess.Board) -> str:
+    outcome = board.outcome()
+    if outcome is None:
+        return ""
+    if outcome.winner is None:
+        return f"Draw ({outcome.termination.name.lower().replace('_', ' ')}). New game?"
+    who = "You win! 🎉" if outcome.winner == chess.WHITE else "ChessTransformer wins."
+    return f"Checkmate — {who} New game?"
+
+
+def on_move(fen: str, sims: int):
+    """Human just moved (White). Reply with the bot's move (Black)."""
+    board = chess.Board(fen)
+    if board.is_game_over():
+        return fen, _result_text(board)
+
+    bot.num_simulations = int(sims)
+    uci, value = bot.predict(board)
+    board.push_uci(uci)
+
+    move_san = "—"
+    tmp = chess.Board(fen)
+    try:
+        move_san = tmp.san(chess.Move.from_uci(uci))
+    except Exception:
+        move_san = uci
+
+    if board.is_game_over():
+        status = f"Bot played **{move_san}**.  {_result_text(board)}"
+    else:
+        eval_str = f"  (eval {value:+.2f})" if value is not None else ""
+        status = f"Bot played **{move_san}**{eval_str}.  Your move."
+    return board.fen(), status
+
+
+def new_game():
+    return START_FEN, "New game — you are **White**. Make your move."
+
+
+with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
+    gr.Markdown(
+        "# ♟️ ChessTransformer\n"
+        "An **11.7M-parameter transformer trained only on human games** "
+        "(no self-play, no RL), playing via AlphaZero-style MCTS. "
+        "It reaches **~2100 Elo** vs Stockfish at full strength; this CPU demo "
+        "runs at a lower sim count so moves come back quickly.\n\n"
+        "**You play White.** Drag a piece to move — the bot replies automatically.  "
+        "[GitHub repo →](https://github.com/tchauffi/ChessTransformer)"
+    )
+    with gr.Row():
+        with gr.Column(scale=3):
+            board = Chessboard(value=START_FEN, game_mode=True, orientation="white",
+                               label="Drag to move (you are White)")
+        with gr.Column(scale=1):
+            status = gr.Markdown("You are **White**. Make your move.")
+            sims = gr.Slider(32, 400, value=DEFAULT_SIMS, step=8, label="Engine strength (MCTS sims/move)",
+                             info="Higher = stronger but slower on CPU")
+            new_btn = gr.Button("New game", variant="primary")
+
+    board.move(on_move, inputs=[board, sims], outputs=[board, status])
+    new_btn.click(new_game, outputs=[board, status])
+
+
+if __name__ == "__main__":
+    demo.launch()

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -78,43 +78,56 @@ bot = Pos2MoveV2MctsBot(
 )
 
 
-def _result_text(board: chess.Board) -> str:
+def _human_color(human_color: str) -> bool:
+    return chess.BLACK if human_color == "black" else chess.WHITE
+
+
+def _result_text(board: chess.Board, human_color: str) -> str:
     outcome = board.outcome()
     if outcome is None:
         return ""
     if outcome.winner is None:
         return f"Draw ({outcome.termination.name.lower().replace('_', ' ')}). New game?"
-    who = "You win! 🎉" if outcome.winner == chess.WHITE else "ChessTransformer wins."
+    who = "You win! 🎉" if outcome.winner == _human_color(human_color) else "ChessTransformer wins."
     return f"Checkmate — {who} New game?"
 
 
-def on_move(fen: str, sims: int):
-    """Human just moved (White). Reply with the bot's move (Black)."""
-    board = chess.Board(fen)
-    if board.is_game_over():
-        return fen, _result_text(board)
-
+def _bot_move(board: chess.Board, sims: int):
+    """Play the side to move with the bot; return its SAN and value."""
     bot.num_simulations = int(sims)
     uci, value = bot.predict(board)
+    san = board.san(chess.Move.from_uci(uci))
     board.push_uci(uci)
+    return san, value
 
-    move_san = "—"
-    tmp = chess.Board(fen)
-    try:
-        move_san = tmp.san(chess.Move.from_uci(uci))
-    except Exception:
-        move_san = uci
+
+def on_move(fen: str, sims: int, human_color: str):
+    """Human just moved; reply with the bot's move (whichever side is to move)."""
+    board = chess.Board(fen)
+    if board.is_game_over():
+        return board.fen(), _result_text(board, human_color)
+
+    san, value = _bot_move(board, sims)
 
     if board.is_game_over():
-        status = f"Bot played **{move_san}**.  {_result_text(board)}"
+        status = f"Bot played **{san}**.  {_result_text(board, human_color)}"
     else:
         eval_str = f"  (eval {value:+.2f})" if value is not None else ""
-        status = f"Bot played **{move_san}**{eval_str}.  Your move."
+        status = f"Bot played **{san}**{eval_str}.  Your move."
     return board.fen(), status
 
 
-def new_game():
-    return START_FEN, "New game — you are **White**. Make your move."
+def new_game(play_as: str, sims: int):
+    """Start a fresh game. If the human plays Black, the bot (White) opens."""
+    human_color = "black" if play_as == "Black" else "white"
+    orientation = human_color
+    board = chess.Board()
+    if human_color == "black":
+        san, _ = _bot_move(board, sims)
+        status = f"New game — you are **Black**. Bot opened with **{san}**. Your move."
+    else:
+        status = "New game — you are **White**. Make your move."
+    return gr.update(value=board.fen(), orientation=orientation), status, human_color
 
 
 with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
@@ -124,21 +137,24 @@ with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
         "(no self-play, no RL), playing via AlphaZero-style MCTS. "
         "It reaches **~2100 Elo** vs Stockfish at full strength; this CPU demo "
         "runs at a lower sim count so moves come back quickly.\n\n"
-        "**You play White.** Drag a piece to move — the bot replies automatically.  "
+        "**Pick your color and hit New game.** Drag a piece to move — the bot "
+        "replies automatically.  "
         "[GitHub repo →](https://github.com/tchauffi/ChessTransformer)"
     )
+    human_color = gr.State("white")
     with gr.Row():
         with gr.Column(scale=3):
             board = Chessboard(value=START_FEN, game_mode=True, orientation="white",
-                               label="Drag to move (you are White)")
+                               label="Drag to move")
         with gr.Column(scale=1):
             status = gr.Markdown("You are **White**. Make your move.")
+            play_as = gr.Radio(["White", "Black"], value="White", label="Play as")
             sims = gr.Slider(32, 1200, value=DEFAULT_SIMS, step=8, label="Engine strength (MCTS sims/move)",
                              info="Higher = stronger but slower on CPU")
             new_btn = gr.Button("New game", variant="primary")
 
-    board.move(on_move, inputs=[board, sims], outputs=[board, status])
-    new_btn.click(new_game, outputs=[board, status])
+    board.move(on_move, inputs=[board, sims, human_color], outputs=[board, status])
+    new_btn.click(new_game, inputs=[play_as, sims], outputs=[board, status, human_color])
 
 
 if __name__ == "__main__":

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -117,17 +117,21 @@ def on_move(fen: str, sims: int, human_color: str):
     return board.fen(), status
 
 
-def new_game(play_as: str, sims: int):
-    """Start a fresh game. If the human plays Black, the bot (White) opens."""
+def new_game(play_as: str, sims: int) -> dict:
+    """Start a fresh game. If the human plays Black, the bot (White) opens.
+
+    Returns a ``setup`` dict that drives a ``gr.render`` block — changing it
+    rebuilds the board so its orientation (chessboard.js, set only at mount)
+    actually flips."""
     human_color = "black" if play_as == "Black" else "white"
-    orientation = human_color
     board = chess.Board()
     if human_color == "black":
         san, _ = _bot_move(board, sims)
         status = f"New game — you are **Black**. Bot opened with **{san}**. Your move."
     else:
         status = "New game — you are **White**. Make your move."
-    return gr.update(value=board.fen(), orientation=orientation), status, human_color
+    return {"fen": board.fen(), "orientation": human_color,
+            "color": human_color, "status": status}
 
 
 with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
@@ -141,20 +145,35 @@ with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
         "replies automatically.  "
         "[GitHub repo →](https://github.com/tchauffi/ChessTransformer)"
     )
-    human_color = gr.State("white")
-    with gr.Row():
-        with gr.Column(scale=3):
-            board = Chessboard(value=START_FEN, game_mode=True, orientation="white",
-                               label="Drag to move")
-        with gr.Column(scale=1):
-            status = gr.Markdown("You are **White**. Make your move.")
-            play_as = gr.Radio(["White", "Black"], value="White", label="Play as")
-            sims = gr.Slider(32, 1200, value=DEFAULT_SIMS, step=8, label="Engine strength (MCTS sims/move)",
-                             info="Higher = stronger but slower on CPU")
-            new_btn = gr.Button("New game", variant="primary")
+    setup = gr.State({"fen": START_FEN, "orientation": "white",
+                      "color": "white", "status": "You are **White**. Make your move."})
 
-    board.move(on_move, inputs=[board, sims, human_color], outputs=[board, status])
-    new_btn.click(new_game, inputs=[play_as, sims], outputs=[board, status, human_color])
+    with gr.Row():
+        board_col = gr.Column(scale=3)
+        ctrl_col = gr.Column(scale=1)
+
+    # Controls first so `sims` exists when the render block references it.
+    with ctrl_col:
+        play_as = gr.Radio(["White", "Black"], value="White", label="Play as")
+        sims = gr.Slider(32, 1200, value=DEFAULT_SIMS, step=8,
+                         label="Engine strength (MCTS sims/move)",
+                         info="Higher = stronger but slower on CPU")
+        new_btn = gr.Button("New game", variant="primary")
+
+    # The board lives in a gr.render so switching color rebuilds it with the new
+    # orientation (chessboard.js only reads orientation at construction).
+    with board_col:
+        @gr.render(inputs=setup)
+        def render_board(cfg):
+            board = Chessboard(value=cfg["fen"], game_mode=True,
+                               orientation=cfg["orientation"], label="Drag to move")
+            status = gr.Markdown(cfg["status"])
+            board.move(
+                lambda fen, s, _c=cfg["color"]: on_move(fen, s, _c),
+                inputs=[board, sims], outputs=[board, status],
+            )
+
+    new_btn.click(new_game, inputs=[play_as, sims], outputs=[setup])
 
 
 if __name__ == "__main__":

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -75,6 +75,10 @@ bot = Pos2MoveV2MctsBot(
     device="cpu",
     compile=False,
     time_limit=0.0,
+    # Sample the opening moves (∝ visit count) so games aren't identical every
+    # time; switches to deterministic best-move play after the opening.
+    move_temp=1.0,
+    move_temp_plies=12,
 )
 
 

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -12,6 +12,7 @@ Weights are resolved in this order:
 
 from __future__ import annotations
 
+import itertools
 import os
 import sys
 from pathlib import Path
@@ -121,6 +122,12 @@ def on_move(fen: str, sims: int, human_color: str):
     return board.fen(), status
 
 
+# Monotonic id so every New game yields a *distinct* setup dict. Without it,
+# replaying with the same colour returns an identical dict and the gr.render
+# block sees no change — so the board wouldn't reset.
+_game_counter = itertools.count(1)
+
+
 def new_game(play_as: str, sims: int) -> dict:
     """Start a fresh game. If the human plays Black, the bot (White) opens.
 
@@ -135,7 +142,7 @@ def new_game(play_as: str, sims: int) -> dict:
     else:
         status = "New game — you are **White**. Make your move."
     return {"fen": board.fen(), "orientation": human_color,
-            "color": human_color, "status": status}
+            "color": human_color, "status": status, "nonce": next(_game_counter)}
 
 
 with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
@@ -149,8 +156,8 @@ with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
         "replies automatically.  "
         "[GitHub repo →](https://github.com/tchauffi/ChessTransformer)"
     )
-    setup = gr.State({"fen": START_FEN, "orientation": "white",
-                      "color": "white", "status": "You are **White**. Make your move."})
+    setup = gr.State({"fen": START_FEN, "orientation": "white", "color": "white",
+                      "status": "You are **White**. Make your move.", "nonce": 0})
 
     with gr.Row():
         board_col = gr.Column(scale=3)

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -87,6 +87,35 @@ def _human_color(human_color: str) -> bool:
     return chess.BLACK if human_color == "black" else chess.WHITE
 
 
+def _white_pov_value(board: chess.Board) -> float:
+    """Value-head eval in [-1, 1] from White's perspective (+ = White better)."""
+    if board.is_game_over():
+        if board.is_checkmate():
+            return -1.0 if board.turn == chess.WHITE else 1.0
+        return 0.0  # stalemate / draw
+    v = bot.get_value(board)
+    if v is None:
+        return 0.0
+    return v if board.turn == chess.WHITE else -v
+
+
+def eval_bar_html(board: chess.Board, orientation: str) -> str:
+    """A vertical eval bar (White share fills from the bottom of White's side).
+    Flipped to match the board orientation so the viewer's side is at the bottom."""
+    wv = _white_pov_value(board)
+    white_pct = round(max(0.0, min(1.0, (wv + 1) / 2)) * 100, 1)
+    white_div = f'<div style="height:{white_pct}%;background:#f5f5f5;"></div>'
+    black_div = f'<div style="height:{round(100 - white_pct, 1)}%;background:#3a3a3a;"></div>'
+    # orientation "white": Black on top, White on bottom; flipped when "black".
+    segments = black_div + white_div if orientation == "white" else white_div + black_div
+    return (
+        f'<div title="Model eval (White POV): {wv:+.2f}" '
+        'style="display:flex;flex-direction:column;width:26px;height:460px;'
+        'border:1px solid #999;border-radius:4px;overflow:hidden;">'
+        f'{segments}</div>'
+    )
+
+
 def _result_text(board: chess.Board, human_color: str) -> str:
     outcome = board.outcome()
     if outcome is None:
@@ -107,10 +136,11 @@ def _bot_move(board: chess.Board, sims: int):
 
 
 def on_move(fen: str, sims: int, human_color: str):
-    """Human just moved; reply with the bot's move (whichever side is to move)."""
+    """Human just moved; reply with the bot's move (whichever side is to move).
+    The human's board orientation equals their color."""
     board = chess.Board(fen)
     if board.is_game_over():
-        return board.fen(), _result_text(board, human_color)
+        return board.fen(), _result_text(board, human_color), eval_bar_html(board, human_color)
 
     san, value = _bot_move(board, sims)
 
@@ -119,7 +149,7 @@ def on_move(fen: str, sims: int, human_color: str):
     else:
         eval_str = f"  (eval {value:+.2f})" if value is not None else ""
         status = f"Bot played **{san}**{eval_str}.  Your move."
-    return board.fen(), status
+    return board.fen(), status, eval_bar_html(board, human_color)
 
 
 # Monotonic id so every New game yields a *distinct* setup dict. Without it,
@@ -141,8 +171,9 @@ def new_game(play_as: str, sims: int) -> dict:
         status = f"New game — you are **Black**. Bot opened with **{san}**. Your move."
     else:
         status = "New game — you are **White**. Make your move."
-    return {"fen": board.fen(), "orientation": human_color,
-            "color": human_color, "status": status, "nonce": next(_game_counter)}
+    setup = {"fen": board.fen(), "orientation": human_color,
+             "color": human_color, "status": status, "nonce": next(_game_counter)}
+    return setup, eval_bar_html(board, human_color)
 
 
 with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
@@ -160,8 +191,13 @@ with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
                       "status": "You are **White**. Make your move.", "nonce": 0})
 
     with gr.Row():
+        eval_col = gr.Column(scale=0, min_width=40)
         board_col = gr.Column(scale=3)
         ctrl_col = gr.Column(scale=1)
+
+    # Eval bar (persistent, hidden by default) — sits left of the board.
+    with eval_col:
+        eval_bar = gr.HTML(eval_bar_html(chess.Board(), "white"), visible=False)
 
     # Controls first so `sims` exists when the render block references it.
     with ctrl_col:
@@ -169,6 +205,7 @@ with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
         sims = gr.Slider(32, 1200, value=DEFAULT_SIMS, step=8,
                          label="Engine strength (MCTS sims/move)",
                          info="Higher = stronger but slower on CPU")
+        show_eval = gr.Checkbox(False, label="Show evaluation bar")
         new_btn = gr.Button("New game", variant="primary")
 
     # The board lives in a gr.render so switching color rebuilds it with the new
@@ -181,10 +218,11 @@ with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
             status = gr.Markdown(cfg["status"])
             board.move(
                 lambda fen, s, _c=cfg["color"]: on_move(fen, s, _c),
-                inputs=[board, sims], outputs=[board, status],
+                inputs=[board, sims], outputs=[board, status, eval_bar],
             )
 
-    new_btn.click(new_game, inputs=[play_as, sims], outputs=[setup])
+    show_eval.change(lambda show: gr.update(visible=show), inputs=show_eval, outputs=eval_bar)
+    new_btn.click(new_game, inputs=[play_as, sims], outputs=[setup, eval_bar])
 
 
 if __name__ == "__main__":

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -30,7 +30,7 @@ if (_repo_src / "chesstransformer").exists():
 from chesstransformer.bots import Pos2MoveV2MctsBot  # noqa: E402
 
 START_FEN = chess.STARTING_FEN
-DEFAULT_SIMS = int(os.environ.get("MCTS_SIMS", "200"))
+DEFAULT_SIMS = int(os.environ.get("MCTS_SIMS", "400"))
 
 # GitHub locations for the last-resort weight download.
 _GH = "tchauffi/ChessTransformer"
@@ -133,7 +133,7 @@ with gr.Blocks(title="ChessTransformer", theme=gr.themes.Soft()) as demo:
                                label="Drag to move (you are White)")
         with gr.Column(scale=1):
             status = gr.Markdown("You are **White**. Make your move.")
-            sims = gr.Slider(32, 400, value=DEFAULT_SIMS, step=8, label="Engine strength (MCTS sims/move)",
+            sims = gr.Slider(32, 1200, value=DEFAULT_SIMS, step=8, label="Engine strength (MCTS sims/move)",
                              info="Higher = stronger but slower on CPU")
             new_btn = gr.Button("New game", variant="primary")
 

--- a/hf_space/prepare.sh
+++ b/hf_space/prepare.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Assemble a self-contained Hugging Face Space in hf_space/space_build/, ready to
+# push to a Space git remote. Bundles the app, slim requirements, the
+# chesstransformer package source, and the v2.1 model weights.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+BUILD="$HERE/space_build"
+WEIGHTS="$REPO/data/models/pos2move_v2.1"
+
+if [ ! -f "$WEIGHTS/model.safetensors" ]; then
+  echo "ERROR: weights not found at $WEIGHTS (run git lfs pull?)" >&2
+  exit 1
+fi
+
+rm -rf "$BUILD"
+mkdir -p "$BUILD/model"
+
+cp "$HERE/app.py" "$BUILD/app.py"
+cp "$HERE/requirements.txt" "$BUILD/requirements.txt"
+cp "$HERE/README.md" "$BUILD/README.md"
+
+# Vendor the package source (inference path only needs this subtree).
+cp -r "$REPO/src/chesstransformer" "$BUILD/chesstransformer"
+# Drop bundled data (old model weights / tokenizer blobs ~200 MB) and caches —
+# the inference path loads weights from ./model, not from inside the package.
+rm -rf "$BUILD/chesstransformer/data"
+find "$BUILD/chesstransformer" -name '__pycache__' -type d -prune -exec rm -rf {} +
+find "$BUILD/chesstransformer" -name '*.pyc' -delete
+
+# Bundle weights (HF will store the large file via LFS on push).
+cp "$WEIGHTS/model_config.json" "$BUILD/model/model_config.json"
+cp "$WEIGHTS/model.safetensors" "$BUILD/model/model.safetensors"
+
+# A .gitattributes so the Space tracks the weights with LFS.
+cat > "$BUILD/.gitattributes" <<'EOF'
+*.safetensors filter=lfs diff=lfs merge=lfs -text
+EOF
+
+echo "Built Space at: $BUILD"
+echo "Contents:"
+( cd "$BUILD" && find . -maxdepth 2 -not -path '*/.*' | sort )

--- a/hf_space/requirements.txt
+++ b/hf_space/requirements.txt
@@ -1,0 +1,10 @@
+# Slim CPU runtime for the Space. The chesstransformer package source is
+# vendored next to app.py (see prepare.sh), so only the runtime deps of the
+# inference path are needed here — not the full training stack.
+torch>=2.2
+numpy>=1.26
+python-chess>=1.999
+safetensors>=0.4
+tokenizers>=0.15
+gradio>=5.49.0
+gradio-chessboard>=0.0.10

--- a/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
+++ b/src/chesstransformer/bots/pos2move_v2_mcts_bot.py
@@ -52,11 +52,21 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
         fpu: float | None = 0.2,
         sim_batch: int = 16,
         tree_reuse: bool = True,
+        move_temp: float = 0.0,
+        move_temp_plies: int = 0,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.num_simulations = num_simulations
         self.c_puct = c_puct
+        # Move selection. By default the move is argmax(visit count) — fully
+        # deterministic (what the gauntlet / API rely on). For variety (e.g. so
+        # the opening isn't identical every game), set move_temp > 0 to *sample*
+        # the move ∝ visit_count**(1/move_temp) for the first move_temp_plies
+        # half-moves, then fall back to argmax. move_temp=1 samples proportional
+        # to visits; higher is more random.
+        self.move_temp = move_temp
+        self.move_temp_plies = move_temp_plies
         # Tree reuse: keep the searched subtree under the moves actually played
         # and re-root it next move, so prior visits carry over (effectively
         # deeper search for free). Requires the caller to keep board.move_stack
@@ -257,7 +267,15 @@ class Pos2MoveV2MctsBot(Pos2MoveV2Bot):
                 self._run_batch(root, board, n)
                 done += n
 
-        best_idx = int(np.argmax(root.child_N))
+        ply = 2 * (board.fullmove_number - 1) + (0 if board.turn == chess.WHITE else 1)
+        if self.move_temp > 0 and ply < self.move_temp_plies and root.child_N.sum() > 0:
+            # Sample ∝ visit_count**(1/temp) over the opening plies for variety.
+            weights = root.child_N.astype(np.float64) ** (1.0 / self.move_temp)
+            total = weights.sum()
+            best_idx = int(np.random.choice(len(weights), p=weights / total)) if total > 0 \
+                else int(np.argmax(root.child_N))
+        else:
+            best_idx = int(np.argmax(root.child_N))
         best_move = root.moves[best_idx]
         n = int(root.child_N[best_idx])
         # Root value from side-to-move POV (negate child's POV).


### PR DESCRIPTION
## What

A self-contained **Hugging Face Space** (Gradio) so anyone can play the bot in-browser — no GPU, no signup. This removes the "can't try it out" barrier that gets Show HN posts flagged.

## Contents (`hf_space/`)

- **`app.py`** — Gradio UI using the `gradio-chessboard` component. Human plays White (drag to move), the MCTS bot replies. Runs on CPU (`compile=False`), with a strength slider (MCTS sims/move, default 200 ≈ ~1.5s/move on the free 2-vCPU tier).
- **`prepare.sh`** — assembles a deployable bundle: vendors the slim `chesstransformer` package source + v2.1 weights, excluding ~200 MB of stale in-package model blobs the inference path doesn't use. Final bundle ≈ 45 MB.
- **`requirements.txt`** — slim CPU runtime (no training stack).
- **`README.md`** — HF Space config (YAML frontmatter).
- **`DEPLOY.md`** — step-by-step deploy guide.

## Testing

Verified locally end-to-end:
- App imports, bot loads on CPU.
- Move handler: e4 → bot c5; d4 → bot Nf6; eval reported; new-game resets.
- `prepare.sh` bundle resolves weights from `./model` and plays in the Space layout.

The `gradio-chessboard` drag-to-move frontend only renders in a real browser, so a quick click-test on the live Space is recommended before re-posting.

## Notes

- `hf_space/space_build/` (the assembled bundle) is gitignored.
- Actual HF deploy requires the maintainer's HF account/token (see `DEPLOY.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)