### PR TITLE
Ship base int8 model (LFS) + use it across all deliveries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -74,5 +74,5 @@ benchmark_results.json
 
 # Rust (ct-bot image builds from source; never ship the target dir)
 rust/target
-# Model served by the Rust backend (int8: ~1.75x faster on the CPU EP)
-!data/models/pos2move_v2.1/model_ema.int8.onnx
+# Model used by the Rust backend (base int8: ~1.75x faster on the CPU EP)
+!data/models/pos2move_v2.1/model.int8.onnx

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 **.pth filter=lfs diff=lfs merge=lfs -text
 *.safetensors filter=lfs diff=lfs merge=lfs -text
+*.onnx filter=lfs diff=lfs merge=lfs -text

--- a/data/models/pos2move_v2.1/model.int8.onnx
+++ b/data/models/pos2move_v2.1/model.int8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd429262f8c7fae72e7cd6f9298c7a49c2829bf860dea044dbf17b5ee1fc599a
+size 15933605

--- a/rust/ct-bot/Dockerfile
+++ b/rust/ct-bot/Dockerfile
@@ -21,11 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY --from=builder /build/rust/target/release/ct-bot /usr/local/bin/ct-bot
 # ONNX Runtime (CPU) is statically linked; only the model is needed at runtime.
-# The int8 model is ~1.75x faster on the CPU EP with negligible quality loss
-# (generate with: export_onnx.py <dir> --ema --quantize).
-COPY data/models/pos2move_v2.1/model_ema.int8.onnx ./model_ema.int8.onnx
+# Base int8 model — the single model used across all deliveries (default, serve,
+# lichess): ~1.75x faster on the CPU EP, and the base net scales with search far
+# better than EMA (generate with: export_onnx.py <dir> --quantize).
+COPY data/models/pos2move_v2.1/model.int8.onnx ./model.int8.onnx
 
 EXPOSE 5001
 ENV RUST_LOG=info
 
-CMD ["ct-bot", "serve", "--model", "/app/model_ema.int8.onnx", "--port", "5001"]
+CMD ["ct-bot", "serve", "--model", "/app/model.int8.onnx", "--port", "5001"]

--- a/rust/ct-bot/src/main.rs
+++ b/rust/ct-bot/src/main.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 
-const DEFAULT_MODEL: &str = "data/models/pos2move_v2.1/model_ema.onnx";
+const DEFAULT_MODEL: &str = "data/models/pos2move_v2.1/model.int8.onnx";
 
 #[derive(Parser)]
 #[command(name = "ct-bot", about = "ChessTransformer Rust bot")]

--- a/scripts/sims_scaling.py
+++ b/scripts/sims_scaling.py
@@ -99,7 +99,7 @@ def main():
                    help="cuda uses torch.compile for fast, clean measurement (run when GPU is free)")
     p.add_argument("--engine-cmd", default=None,
                    help="UCI engine command to test instead of the Python bot, e.g. "
-                        "'rust/target/release/ct-bot uci --model data/models/pos2move_v2.1/model_ema.onnx'. "
+                        "'rust/target/release/ct-bot uci --model data/models/pos2move_v2.1/model.int8.onnx'. "
                         "Raise --level-timeout for high sim counts.")
     p.add_argument("--out-json", default="docs/strength_vs_sims.json")
     p.add_argument("--out-png", default="docs/strength_vs_sims.png")


### PR DESCRIPTION
Follow-up to #20 (merged). Makes the ct-bot engine self-contained and the model choice consistent.

## What
- **Ships `model.int8.onnx` (base, int8) via Git LFS** (`*.onnx` now LFS-tracked) — the engine builds and runs from a fresh clone, no `export_onnx.py` step needed.
- **Consolidates every delivery on this one model:**
  - `main.rs` `DEFAULT_MODEL` → `model.int8.onnx`
  - Docker `serve` → `model.int8.onnx` (+ `.dockerignore` exception)
  - `sims_scaling --engine-cmd` example updated

## Why
Resolves the model/cap mismatch flagged in #20's review: `MAX_SIMS=4000` is tuned for the **base** net (sound to ~5000 sims), but the default model and Docker were still pointing at the **EMA** net (degrades past ~2000 → plays `1.h4` junk). Now the cap and the model agree at every entry point.

Background: base ≈ EMA at the operating point (head-to-head @1800: 1W-13D-2L), but base scales far deeper (base@3600 vs base@1800: 3W-13D-0L, never lost). The live lichess bot already runs this config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)